### PR TITLE
Support environment proxy

### DIFF
--- a/jobs/cpi/spec
+++ b/jobs/cpi/spec
@@ -74,3 +74,9 @@ properties:
   nats.port:
     description: Port that the nats server listens on
     default: 4222
+  env.http_proxy:
+    description: Http proxy to connect to cloud API's
+  env.https_proxy:
+    description: Https proxy to connect to cloud API's
+  env.no_proxy:
+    description: No Proxy environment variable

--- a/jobs/cpi/templates/cpi.erb
+++ b/jobs/cpi/templates/cpi.erb
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+<% if_p('env.http_proxy') do |http_proxy| %>
+	export HTTP_PROXY=<%= http_proxy %>
+	export http_proxy=<%= http_proxy %>
+<% end %>
+<% if_p('env.https_proxy') do |https_proxy| %>
+	export HTTPS_PROXY=<%= https_proxy %>
+	export https_proxy=<%= https_proxy %>
+<% end %>
+<% if_p('env.no_proxy') do |no_proxy| %>
+	export NO_PROXY=<%= no_proxy %>
+	export no_proxy=<%= no_proxy %>
+<% end %>
+
 read INPUT
 
 BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}


### PR DESCRIPTION
Deployment using bosh-init need env proxy if there is a proxy between the deployment vm and cloud api .