### PR TITLE
Add cpu & memory hot add enable option

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -1,6 +1,6 @@
 module VSphereCloud
   class VmCreator
-    def initialize(memory, disk_size_in_mb, cpu, nested_hardware_virtualization, drs_rules, client, cloud_searcher, logger, cpi, agent_env, file_provider, datacenter, cluster=nil)
+    def initialize(memory, disk_size_in_mb, cpu, cpu_hot_add_enabled, mem_hot_add_enabled, nested_hardware_virtualization, drs_rules, client, cloud_searcher, logger, cpi, agent_env, file_provider, datacenter, cluster=nil)
       @drs_rules = drs_rules
       @client = client
       @cloud_searcher = cloud_searcher
@@ -9,6 +9,8 @@ module VSphereCloud
       @memory = memory
       @disk_size_in_mb = disk_size_in_mb
       @cpu = cpu
+      @cpu_hot_add_enabled = cpu_hot_add_enabled
+      @mem_hot_add_enabled = mem_hot_add_enabled
       @nested_hardware_virtualization = nested_hardware_virtualization
       @agent_env = agent_env
       @file_provider = file_provider
@@ -54,6 +56,8 @@ module VSphereCloud
 
       config_hash = {memory_mb: @memory, num_cpus: @cpu}
       config_hash.merge!(nested_hv_enabled: true) if @nested_hardware_virtualization
+      config_hash.merge!(cpu_hot_add_enabled: true) if @cpu_hot_add_enabled
+      config_hash.merge!(memory_hot_add_enabled: true) if @mem_hot_add_enabled
 
       config = VimSdk::Vim::Vm::ConfigSpec.new(config_hash)
       config.device_change = []

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator_builder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator_builder.rb
@@ -7,6 +7,8 @@ module VSphereCloud
         cloud_properties.fetch('ram'),
         cloud_properties.fetch('disk'),
         cloud_properties.fetch('cpu'),
+        cloud_properties.fetch('cpu_hot_add_enabled', false),
+        cloud_properties.fetch('mem_hot_add_enabled', false),
         cloud_properties.fetch('nested_hardware_virtualization', false),
         drs_rules,
         client,

--- a/src/vsphere_cpi/lib/ruby_vim_sdk/vmodl_helper.rb
+++ b/src/vsphere_cpi/lib/ruby_vim_sdk/vmodl_helper.rb
@@ -1,6 +1,8 @@
 module VimSdk::VmodlHelper
   UNDERSCORE_EXCEPTIONS = {
     "numCPUs" => "num_cpus",
+    "cpuHotAddEnabled" => "cpu_hot_add_enabled",
+    "memoryHotAddEnabled" => "memory_hot_add_enabled",
     "importVApp" => "import_vapp"
   }
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_creator_builder_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_creator_builder_spec.rb
@@ -30,11 +30,13 @@ module VSphereCloud
       end
 
       context 'when nested_hardware_virtualization is not specified' do
-        it 'injects the memory size, disk size, number of cpu, vsphere client, logger, drs rules and the cpi into the VmCreator instance' do
+        it 'injects the memory size, disk size, number of cpu, cpu hot add enable, mem hot add enable, vsphere client, logger, drs rules and the cpi into the VmCreator instance' do
           expect(VSphereCloud::VmCreator).to receive(:new).with(
               memory,
               disk,
               cpu,
+              false,
+              false,
               false,
               drs_rules,
               client,
@@ -63,6 +65,8 @@ module VSphereCloud
               memory,
               disk,
               cpu,
+              false,
+              false,
               true,
               drs_rules,
               client,

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_creator_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_creator_spec.rb
@@ -3,8 +3,10 @@ require 'cloud/vsphere/drs_rules/drs_rule'
 
 describe VSphereCloud::VmCreator do
   subject(:creator) do
-    described_class.new(1024, 1024, 3, nested_hardware_virtualization, [], vsphere_client, cloud_searcher, logger, cpi, agent_env, file_provider, datacenter, cluster)
+    described_class.new(1024, 1024, 3, cpu_hot_add_enabled, mem_hot_add_enabled, nested_hardware_virtualization, [], vsphere_client, cloud_searcher, logger, cpi, agent_env, file_provider, datacenter, cluster)
   end
+  let(:cpu_hot_add_enabled) {false}
+  let(:mem_hot_add_enabled) {false}
   let(:nested_hardware_virtualization) { false }
   let(:vsphere_client) { instance_double('VSphereCloud::VCenterClient', cloud_searcher: cloud_searcher) }
   let(:logger) { double('logger', debug: nil, info: nil) }
@@ -209,7 +211,7 @@ describe VSphereCloud::VmCreator do
 
     context 'without predetermined cluster' do
       subject(:creator) do
-        described_class.new(1024, 1024, 3, nested_hardware_virtualization, [], vsphere_client, cloud_searcher, logger, cpi, agent_env, file_provider, datacenter, nil)
+        described_class.new(1024, 1024, 3, cpu_hot_add_enabled, mem_hot_add_enabled, nested_hardware_virtualization, [], vsphere_client, cloud_searcher, logger, cpi, agent_env, file_provider, datacenter, nil)
       end
       it 'chooses the placement based on memory, ephemeral and persistent disks' do
         expect(datacenter).to receive(:pick_cluster_for_vm).with(1024, 2049, persistent_disks).and_return(cluster)
@@ -253,7 +255,7 @@ describe VSphereCloud::VmCreator do
 
     describe 'DRS rules' do
       subject(:creator) do
-        described_class.new(1024, 1024, 3, nested_hardware_virtualization, drs_rules, vsphere_client, cloud_searcher, logger, cpi, agent_env, file_provider, datacenter, nil)
+        described_class.new(1024, 1024, 3, cpu_hot_add_enabled, mem_hot_add_enabled, nested_hardware_virtualization, drs_rules, vsphere_client, cloud_searcher, logger, cpi, agent_env, file_provider, datacenter, nil)
       end
       context 'when several DRS rules are specified in cloud properties' do
         let(:drs_rules) do


### PR DESCRIPTION
- PR add option to create vm with cpu & memory hot add enabled which can let users add cpu & memory on a running instance.

     References:
[cpu hot add enabled](https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.ConfigInfo.html#cpuHotAddEnabled)
[memory hot add enabled](https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.ConfigInfo.html#memoryHotAddEnabled)

- For now cpu can be increased from vsphere web client . 

Can be enabled as a resource pool property
```yaml
cloud_properties:
    cpu: 2
    ram: 4_096
    disk: 20_000
    cpu_hot_add_enabled: true
    mem_hot_add_enabled: true
```