### PR TITLE
Fixes bug with inaccessible datastores

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster.rb
@@ -65,8 +65,12 @@ module VSphereCloud
           @client,
           properties['datastore']
         ).inject({}) do |acc, datastore|
-          acc[datastore.name] = datastore
-          acc
+          if datastore.accessible == false
+            acc
+          else
+            acc[datastore.name] = datastore
+            acc
+          end
         end
       end
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datastore_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datastore_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 
 describe VSphereCloud::Resources::Datastore do
   subject(:datastore) {
-    VSphereCloud::Resources::Datastore.new('foo_lun', datastore_mob, 16 * 1024, 8 * 1024)
+    VSphereCloud::Resources::Datastore.new('foo_lun', datastore_mob,  true, 16 * 1024, 8 * 1024)
+  }
+  subject(:datastore_inaccess) {
+    VSphereCloud::Resources::Datastore.new('foo_lun', datastore_mob,  false, 16 * 1024, 8 * 1024)
   }
 
   let(:datastore_mob) { instance_double('VimSdk::Vim::Datastore', to_s: 'mob_as_string') }
@@ -23,11 +26,17 @@ describe VSphereCloud::Resources::Datastore do
     it 'returns the total space' do
       expect(datastore.total_space).to eq(16384)
     end
+    it 'returns zero total space for inaccessible datastores' do
+      expect(datastore_inaccess.total_space).to eq(0)
+    end
   end
 
   describe '#free_space' do
     it 'returns the free space' do
       expect(datastore.free_space).to eq(8192)
+    end
+    it 'returns zero free space for inaccessible datastores' do
+      expect(datastore_inaccess.free_space).to eq(0)
     end
   end
 


### PR DESCRIPTION
Accessing summary or info attributes on a datastore that is inaccessible will lead to an error,
this fix checks the datastore is accessible before querying any other properties.  Inaccessible
datastores are also dropped from disk placement consideration.

In practice, this manifested during a bosh-init director upgrade where attach_disk is called to remount the persistent_disk on a new VM/stemcell.   We have a customer that is performing a SAN migration and has 50+ inactive datastores on some ESX hosts. 

For more info see the docs on the Accessible property: https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.Datastore.Summary.html

Test Scenario:  vCenter 6 , ESX 6 , One Hypervisor, Two Datastores (Datastore1 active, Datastore2 inactive), 
bosh-init before fix:
```
Started validating
  Validating release 'bosh'... Finished (00:00:02)
  Validating release 'bosh-vsphere-cpi'... Finished (00:00:00)
  Validating cpi release... Finished (00:00:00)
  Validating deployment manifest... Finished (00:00:00)
  Validating stemcell... Finished (00:00:18)
Finished validating (00:00:20)

Started installing CPI
  Compiling package 'vsphere_cpi_ruby/115f05074e854ee7e83bc4872147d6b8c5c3f049'... Finished (00:00:00)
  Compiling package 'vsphere_cpi/a15046b1531471fa43ab38bcadfd9182fafd3d90'... Finished (00:00:00)
  Compiling package 'vsphere_cpi_mkisofs/375b8278d67b41609bec988a81a6cdc9a739d775'... Finished (00:00:00)
  Installing packages... Finished (00:00:03)
  Rendering job templates... Finished (00:00:00)
  Installing job 'vsphere_cpi'... Finished (00:00:00)
Finished installing CPI (00:00:04)

Starting registry... Finished (00:00:00)
Uploading stemcell 'bosh-vsphere-esxi-ubuntu-trusty-go_agent/3262.2'... Skipped [Stemcell already uploaded] (00:00:00)

Started deploying
  Creating VM for instance 'bosh/0' from stemcell 'sc-9143f8f0-a93f-4144-8710-441e44103a11'... Finished (00:00:17)
  Waiting for the agent on VM 'vm-42155def-354c-40b0-9e0b-5d10ad814273' to be ready... Finished (00:00:38)
  Attaching disk 'disk-09acfac9-cbbb-4059-91b9-d21bad76af39' to VM 'vm-42155def-354c-40b0-9e0b-5d10ad814273'... Failed (00:00:03)
Failed deploying (00:00:59)

Stopping registry... Finished (00:00:00)
Cleaning up rendered CPI jobs... Finished (00:00:00)

Command 'deploy' failed:
  Deploying:
    Creating instance 'bosh/0':
      Updating instance disks:
        Updating disks:
          Deploying disk:
            Attaching disk in the cloud:
              CPI 'attach_disk' method responded with error: CmdError{"type":"Unknown","message":"Datastore 'Datastore2' is not accessible. No connected and accessible host is attached to this datastore.","ok_to_retry":false}
```

bosh-init after fix:
```
Started validating
  Validating release 'bosh'... Finished (00:00:02)
  Validating release 'bosh-vsphere-cpi'... Finished (00:00:00)
  Validating cpi release... Finished (00:00:00)
  Validating deployment manifest... Finished (00:00:00)
  Validating stemcell... Finished (00:00:11)
Finished validating (00:00:13)

Started installing CPI
  Compiling package 'vsphere_cpi_ruby/115f05074e854ee7e83bc4872147d6b8c5c3f049'... Finished (00:00:00)
  Compiling package 'vsphere_cpi/e56aefcde29af2f0b0d6fb57e1b93611b7ec4d58'... Finished (00:00:00)
  Compiling package 'vsphere_cpi_mkisofs/375b8278d67b41609bec988a81a6cdc9a739d775'... Finished (00:00:00)
  Installing packages... Finished (00:00:01)
  Rendering job templates... Finished (00:00:00)
  Installing job 'vsphere_cpi'... Finished (00:00:00)
Finished installing CPI (00:00:01)

Starting registry... Finished (00:00:00)
Uploading stemcell 'bosh-vsphere-esxi-ubuntu-trusty-go_agent/3262.2'... Skipped [Stemcell already uploaded] (00:00:00)

Started deploying
  Creating VM for instance 'bosh/0' from stemcell 'sc-9143f8f0-a93f-4144-8710-441e44103a11'... Finished (00:00:31)
  Waiting for the agent on VM 'vm-28151753-abe0-474a-8f74-73d6f7adf726' to be ready... Finished (00:00:39)
  Attaching disk 'disk-09acfac9-cbbb-4059-91b9-d21bad76af39' to VM 'vm-28151753-abe0-474a-8f74-73d6f7adf726'... Finished (00:00:11)
  Rendering job templates... Finished (00:00:03)
  Compiling package 'ruby/589d4b05b422ac6c92ee7094fc2a402db1f2d731'...
```