### PR TITLE
prevent javax.persistence.OptimisticLockException

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/nsx.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsx.rb
@@ -21,12 +21,12 @@ module VSphereCloud
     end
 
     def add_vm_to_security_group(security_group_name, vm_id)
+      sg_id = find_or_create_security_group(security_group_name)
       i = 0
       Bosh::Retryable.new(tries: MAX_TRIES,
                           sleep: ->(try_count, retry_exception) { 0.5 },
                           on: [Exception],
                           matching: %r{(?:javax.persistence.OptimisticLockException|<errorCode>300<\/errorCode>)}).retryer do
-        sg_id = find_or_create_security_group(security_group_name)
         if i.zero?
           @logger.debug("Adding VM '#{vm_id}' to Security Group '#{security_group_name}'...")
         else

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsx.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsx.rb
@@ -21,32 +21,31 @@ module VSphereCloud
     end
 
     def add_vm_to_security_group(security_group_name, vm_id)
-      sg_id = find_or_create_security_group(security_group_name)
-
-      @retryer.try(MAX_TRIES) do |i|
-        if i == 0
+      i = 0
+      Bosh::Retryable.new(tries: MAX_TRIES,
+                          sleep: ->(try_count, retry_exception) { 0.5 },
+                          on: [Exception],
+                          matching: %r{(?:javax.persistence.OptimisticLockException|<errorCode>300<\/errorCode>)}).retryer do
+        sg_id = find_or_create_security_group(security_group_name)
+        if i.zero?
           @logger.debug("Adding VM '#{vm_id}' to Security Group '#{security_group_name}'...")
         else
           @logger.warn("Retrying adding VM '#{vm_id}' to Security Group '#{security_group_name}', #{i} attempts so far...")
         end
 
+        i += 1
+
         response = @http_client.put("https://#{@nsx_url}/api/2.0/services/securitygroup/#{sg_id}/members/#{vm_id}", nil)
-        unless response.status.between?(200, 299) || vm_belongs_to_security_group?(response.body)
-          unless is_attach_error_retryable?(response.body)
-            raise "Failed to add VM to Security Group with unknown NSX error: '#{response.body}'"
-          end
 
-          err = "Failed to locate VM with VM ID '#{vm_id}' via NSX API: '#{response.body}'"
-          @logger.warn(err)
-          [nil, err]
-        else
-          [response, nil]
+        return true if vm_belongs_to_security_group?(response.body)
+
+        unless response.status.between?(200, 299)
+          raise "Failed to add VM to Security Group with unknown NSX error: '#{response.body}'"
         end
+
+        @logger.debug("Successfully added VM '#{vm_id}' to Security Group '#{security_group_name}'.")
+        response.status.between?(200, 299)
       end
-
-      @logger.debug("Successfully added VM '#{vm_id}' to Security Group '#{security_group_name}'.")
-
-      true
     end
 
     # Note: this method should only be used for cleanup in integration tests
@@ -341,14 +340,6 @@ module VSphereCloud
       end
 
       existing_pool_element.to_xml
-    end
-
-    def is_attach_error_retryable?(xml_content)
-      error_document = Oga.parse_xml(xml_content)
-      error_code_element = error_document.xpath('error/errorCode')
-
-      vm_not_found = (!error_code_element.empty? && error_code_element.text == '300')
-      vm_not_found ? true : false
     end
 
     def vm_belongs_to_security_group?(xml_content)

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsx.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsx.rb
@@ -37,7 +37,10 @@ module VSphereCloud
 
         response = @http_client.put("https://#{@nsx_url}/api/2.0/services/securitygroup/#{sg_id}/members/#{vm_id}", nil)
 
-        return true if vm_belongs_to_security_group?(response.body)
+        if vm_belongs_to_security_group?(response.body)
+          @logger.debug("VM '#{vm_id}' already belongs to Security Group '#{security_group_name}'.")
+          return true
+        end
 
         unless response.status.between?(200, 299)
           raise "Failed to add VM to Security Group with unknown NSX error: '#{response.body}'"

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_spec.rb
@@ -96,32 +96,28 @@ module VSphereCloud
 
       context 'when the add VM to Security Group HTTP request fails' do
         it 'retries until the apply succeeds when call is retryable' do
-          expect(retryer).to receive(:sleep).once
-
           expect_POST_security_group_happy
-          expect_PUT_security_group_vm_sad_retryable
+          expect_PUT_security_group_vm_sad("<error><details>The requested object : #{vm_id} could not be found. Object identifiers are case sensitive.</details><errorCode>300</errorCode><moduleName>core-services</moduleName></error>")
+          expect_POST_security_group_happy
           expect_PUT_security_group_vm_happy
 
           nsx.add_vm_to_security_group(sg_name, vm_id)
         end
 
         it "returns an error after #{VSphereCloud::Retryer::MAX_TRIES} retries when call is retryable" do
-          expect(retryer).to receive(:sleep).exactly(VSphereCloud::NSX::MAX_TRIES - 1).times
-
-          expect_POST_security_group_happy
-
           VSphereCloud::NSX::MAX_TRIES.times do
-            expect_PUT_security_group_vm_sad_retryable
+            expect_POST_security_group_happy
+            expect_PUT_security_group_vm_sad("<error><details>nested exception is javax.persistence.OptimisticLockException</details><errorCode>258</errorCode></error>")
           end
 
           expect {
             nsx.add_vm_to_security_group(sg_name, vm_id)
-          }.to raise_error(/could not be found/)
+          }.to raise_error(/javax.persistence.OptimisticLockException/)
         end
 
         it 'returns an error when the call is not retryable' do
           expect_POST_security_group_happy
-          expect_PUT_security_group_vm_sad_non_retryable
+          expect_PUT_security_group_vm_sad
 
           expect {
             nsx.add_vm_to_security_group(sg_name, vm_id)
@@ -533,14 +529,8 @@ module VSphereCloud
                                .and_return(put_response)
     end
 
-    def expect_PUT_security_group_vm_sad_retryable
-      put_response = double('response', status: 500, body: "<error><details>The requested object : #{vm_id} could not be found. Object identifiers are case sensitive.</details><errorCode>300</errorCode><moduleName>core-services</moduleName></error>")
-      expect(http_client).to receive(:put).with("https://#{nsx_address}/api/2.0/services/securitygroup/#{sg_id}/members/#{vm_id}", nil)
-                               .and_return(put_response)
-    end
-
-    def expect_PUT_security_group_vm_sad_non_retryable
-      put_response = double('response', status: 500, body: 'fake-nsx-error')
+    def expect_PUT_security_group_vm_sad(error = 'fake-nsx-error')
+      put_response = double('response', status: 500, body: error)
       expect(http_client).to receive(:put)
         .with("https://#{nsx_address}/api/2.0/services/securitygroup/#{sg_id}/members/#{vm_id}", nil)
         .and_return(put_response)

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_spec.rb
@@ -98,15 +98,15 @@ module VSphereCloud
         it 'retries until the apply succeeds when call is retryable' do
           expect_POST_security_group_happy
           expect_PUT_security_group_vm_sad("<error><details>The requested object : #{vm_id} could not be found. Object identifiers are case sensitive.</details><errorCode>300</errorCode><moduleName>core-services</moduleName></error>")
-          expect_POST_security_group_happy
           expect_PUT_security_group_vm_happy
 
           nsx.add_vm_to_security_group(sg_name, vm_id)
         end
 
         it "returns an error after #{VSphereCloud::Retryer::MAX_TRIES} retries when call is retryable" do
+          expect_POST_security_group_happy
+
           VSphereCloud::NSX::MAX_TRIES.times do
-            expect_POST_security_group_happy
             expect_PUT_security_group_vm_sad("<error><details>nested exception is javax.persistence.OptimisticLockException</details><errorCode>258</errorCode></error>")
           end
 


### PR DESCRIPTION
### What is it?

If you deploy multiple bosh directors/ deployments to the same vSphere/ NSX the auto configuring of security groups can conflict based on deployment/ job name. This causes security groups to get overwritten and can cause lock exceptions with the nsx api.

This issues is detailed under: https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/issues/28