### PR TITLE
trying to present unitnum with a negative value so let vsphere to ass…

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/nic.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/nic.rb
@@ -36,6 +36,7 @@ module VSphereCloud
         nic.key = -1
         nic.controller_key = controller_key
         nic.backing = backing_info
+        nic.unit_number = -1
 
         nic
       end


### PR DESCRIPTION
I tried to use the latest stemcell with latest CPI on a vSphere 6.0 environment
My use case was trying to add multiple network adaptors to a VM through bosh deployment. 
It worked fine up to 5 nics per VM, but I can not add more than 5, while I can manually add more than 5 through vSphere Client.

After extensive debugging, I suspected that the unit number was causing that the 6th NIC device unit number may be duplicate with other devices. I tried to set a temporary negative value (as the key value) and expect the server side to assign unit number. And it turned out that fixes the problem..... 