### PR TITLE
disk_picker should only consider targetable datastores for balance_score

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/datastore_picker.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/datastore_picker.rb
@@ -91,7 +91,10 @@ module VSphereCloud
     end
 
     def add_balance_score(placement)
-      free_spaces = placement[:datastores].map { |_, ds_data| ds_data[:free_space]}.sort
+      targeted_datastores = placement[:datastores].reject do | _, item |
+        item[:disks].empty?
+      end
+      free_spaces = targeted_datastores.map { |_, ds_data| ds_data[:free_space]}.sort
 
       min = free_spaces.first
       mean = free_spaces.inject(0, &:+) / free_spaces.length


### PR DESCRIPTION
This is a basic PR for https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/issues/35

I hope you will consider merging it if you think the planned refactor https://www.pivotaltracker.com/story/show/151198560 will take some time to prioritize.

Unit tests pass.