### PR TITLE
Corrects calculation of cluster free space based on balanced score

### DIFF
--- a/src/vsphere_cpi/spec/integration/cluster_cloud_properties_spec.rb
+++ b/src/vsphere_cpi/spec/integration/cluster_cloud_properties_spec.rb
@@ -101,7 +101,7 @@ describe 'cloud_properties related to clusters' do
       cpi = VSphereCloud::Cloud.new(options)
       # @cluster_more_memory should have more memory than @cluster_less_memory and
       # both clusters need to have the specified @shared_datastore
-      verify_cluster_free_space(cpi, @cluster_more_datastore_free_space, @cluster_less_datastore_free_space)
+      verify_cluster_free_space_balanced_score(cpi, @cluster_more_datastore_free_space, @cluster_less_datastore_free_space)
     end
     
     let(:vm_type) do


### PR DESCRIPTION
- Adds a method in lifecycle helpers to calculate balanced score based
free space.
- The earlier calculation merely calculated total free space, while creating a vm we use a balanced score based cluster selection.
