### PR TITLE
Network_spec is not memoized anymore through let call

### DIFF
--- a/src/vsphere_cpi/spec/integration/drs_rules_spec.rb
+++ b/src/vsphere_cpi/spec/integration/drs_rules_spec.rb
@@ -16,18 +16,6 @@ describe 'DRS rules', drs: true do
       )
     end
 
-    let(:network_spec) do
-      {
-        'static' => {
-          'ip' => "169.254.#{rand(1..254)}.#{rand(4..254)}",
-          'netmask' => '255.255.254.0',
-          'cloud_properties' => {'name' => @vlan},
-          'default' => ['dns', 'gateway'],
-          'dns' => ['169.254.1.2'],
-          'gateway' => '169.254.1.3'
-        }
-      }
-    end
     let(:vm_type) do
       {
         'ram' => 512,
@@ -46,7 +34,7 @@ describe 'DRS rules', drs: true do
     end
 
     it 'should exercise the vm lifecycle' do
-      vm_lifecycle(one_cluster_cpi, [], vm_type, network_spec, @stemcell_id) do |vm_id|
+      vm_lifecycle(one_cluster_cpi, [], vm_type, get_network_spec, @stemcell_id) do |vm_id|
         vm = one_cluster_cpi.vm_provider.find(vm_id)
 
         datastore = one_cluster_cpi.client.cloud_searcher.get_managed_object(VimSdk::Vim::Datastore, name: @second_datastore)
@@ -99,7 +87,7 @@ describe 'DRS rules', drs: true do
               'agent-007',
               @stemcell_id,
               vm_type,
-              network_spec,
+              get_network_spec,
               [],
               env
             )
@@ -107,7 +95,7 @@ describe 'DRS rules', drs: true do
               'agent-006',
               @stemcell_id,
               vm_type,
-              network_spec,
+              get_network_spec,
               [],
               env
             )
@@ -156,7 +144,7 @@ describe 'DRS rules', drs: true do
               'agent-007',
               @stemcell_id,
               vm_type,
-              network_spec,
+              get_network_spec,
               [],
               {'key' => 'value'}
             )
@@ -164,7 +152,7 @@ describe 'DRS rules', drs: true do
               'agent-006',
               @stemcell_id,
               vm_type,
-              network_spec,
+              get_network_spec,
               [],
               {'key' => 'value'}
             )
@@ -219,7 +207,7 @@ describe 'DRS rules', drs: true do
               'agent-007',
               @stemcell_id,
               vm_type,
-              network_spec,
+              get_network_spec,
               [],
               {'key' => 'value'}
             )
@@ -227,7 +215,7 @@ describe 'DRS rules', drs: true do
               'agent-006',
               @stemcell_id,
               vm_type,
-              network_spec,
+              get_network_spec,
               [],
               {'key' => 'value'}
             )
@@ -277,7 +265,7 @@ describe 'DRS rules', drs: true do
                 'agent-007',
                 @stemcell_id,
                 vm_type,
-                network_spec,
+                get_network_spec,
                 [],
                 {'key' => 'value'}
               )
@@ -300,7 +288,7 @@ describe 'DRS rules', drs: true do
                 'agent-006',
                 @stemcell_id,
                 vm_type,
-                network_spec,
+                get_network_spec,
                 [],
                 {'key' => 'value'}
               )
@@ -327,7 +315,7 @@ describe 'DRS rules', drs: true do
             'agent-007',
             @stemcell_id,
             vm_type,
-            network_spec,
+            get_network_spec,
             [],
             {'key' => 'value'}
           )
@@ -369,7 +357,7 @@ describe 'DRS rules', drs: true do
             'agent-007',
             @stemcell_id,
             vm_type,
-            network_spec,
+            get_network_spec,
             [],
             {'key' => 'value'}
           )

--- a/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
+++ b/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
@@ -162,6 +162,19 @@ module LifecycleHelpers
     fail "Invalid Environment variable '#{env_var_name}': No network named '#{vlan}' found in datacenter named '#{datacenter_name}'" if network.nil?
   end
 
+  def get_network_spec
+  network_spec = {
+    'static' => {
+      'ip' => "169.254.#{rand(1..254)}.#{rand(4..254)}",
+      'netmask' => '255.255.254.0',
+      'cloud_properties' => {'name' => @vlan},
+      'default' => ['dns', 'gateway'],
+      'dns' => ['169.254.1.2'],
+      'gateway' => '169.254.1.3'
+      }
+    }
+  end
+
   def verify_datacenter_exists(cpi, env_var_name)
     cpi.datacenter.mob
   rescue => e


### PR DESCRIPTION
- spec/integration/drs_rules_spec failed due to IP conflict that emerged
due to memoized network_spec. This caused duplicate IP in integration
tests vms.
- New function call randomizes IP every time.
- Still there are slim chances (1/(255*255)) of IP collision. To make
it truly collision free , we can maintain an IP pool per "it" block and use
this pool to get new IP from get_network_spec