### PR TITLE
Make sure cluster 2 has more free space based on configuration

### DIFF
--- a/src/vsphere_cpi/spec/integration/cluster_cloud_properties_spec.rb
+++ b/src/vsphere_cpi/spec/integration/cluster_cloud_properties_spec.rb
@@ -5,11 +5,12 @@ describe 'cloud_properties related to clusters' do
     @datacenter_name = fetch_and_verify_datacenter('BOSH_VSPHERE_CPI_DATACENTER')
 
     @cluster_name = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_CLUSTER')
-    @cluster_name_2 = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_SECOND_CLUSTER')
+    @second_cluster_name = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_SECOND_CLUSTER')
 
     @cluster_more_datastore_free_space = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_CLUSTER_MORE_DATASTORE_FREE_SPACE')
     @cluster_less_datastore_free_space = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_CLUSTER_LESS_DATASTORE_FREE_SPACE')
     @shared_datastore = fetch_property('BOSH_VSPHERE_CPI_SHARED_DATASTORE')
+    @second_cluster_datastore = fetch_and_verify_datastore('BOSH_VSPHERE_CPI_SECOND_CLUSTER_DATASTORE', @second_cluster_name)
   end
 
   let(:network_spec) do
@@ -50,7 +51,7 @@ describe 'cloud_properties related to clusters' do
             'name' => @datacenter_name,
             'clusters' => [
               {
-                @cluster_name_2 => {}
+                @second_cluster_name => {}
               },
             ]
           }
@@ -103,13 +104,13 @@ describe 'cloud_properties related to clusters' do
       # both clusters need to have the specified @shared_datastore
       verify_cluster_free_space(cpi, @cluster_more_datastore_free_space, @cluster_less_datastore_free_space)
     end
-    
+
     let(:vm_type) do
       {
         'ram' => 512,
         'disk' => 2048,
         'cpu' => 1,
-        'datastores' => [@shared_datastore],
+        'datastores' => [@shared_datastore, @second_cluster_datastore],
         'datacenters' => [
           {
             'name' => @datacenter_name,


### PR DESCRIPTION
Our vSphere 6.5 pipelines are broken after the [PR 36](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/pull/36) to change the datastore. We added the fix to take into consideration not only the shared datastore but also another datastore connected to the cluster that is supposed to have more free space.

[#153566963](https://www.pivotaltracker.com/story/show/153566963)

Signed-off-by: Danny Berger <dberger@pivotal.io>