### PR TITLE
Add support for host under maintenance mode

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cluster_picker.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cluster_picker.rb
@@ -47,11 +47,6 @@ module VSphereCloud
               "No valid placement found due to no active host (non-maintenance) present on desired cluster"
       end
 
-      if placement_options.size == 0
-        disk_string = DatastorePicker.pretty_print_disks(disk_configurations)
-        raise Bosh::Clouds::CloudError,
-          "No valid placement found for disks:\n#{disk_string}\n\n#{pretty_print_cluster_disk}"
-      end
       if placement_options.size == 1
         return format_final_placement(placement_options)
       end

--- a/src/vsphere_cpi/lib/cloud/vsphere/cluster_picker.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cluster_picker.rb
@@ -32,7 +32,7 @@ module VSphereCloud
         end
       end.compact.to_h
 
-      if placement_options == nil || placement_options.size == 0
+      if placement_options.nil? || placement_options.size == 0
         disk_string = DatastorePicker.pretty_print_disks(disk_configurations)
         raise Bosh::Clouds::CloudError,
               "No valid placement found for disks:\n#{disk_string}\n\n#{pretty_print_cluster_disk}"
@@ -76,7 +76,7 @@ module VSphereCloud
         cluster.accessible_datastores.each do |dsname, ds|
           unless ds.accessible_from?(cluster)
             datastore_placements = placements[cluster.name][:datastores]
-            datastore_placements.delete(ds.name)
+            datastore_placements.delete(dsname)
             if datastore_placements.length == 0
               placements.delete(cluster.name)
               break

--- a/src/vsphere_cpi/lib/cloud/vsphere/datastore_picker.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/datastore_picker.rb
@@ -68,9 +68,7 @@ module VSphereCloud
 
     def filter_all_placement_without_disks(placement)
       datastore_placements = placement[:datastores]
-
-      iterate_placement = datastore_placements.clone
-      iterate_placement.each do |ds_name, props|
+      datastore_placements.each do |ds_name, props|
         disks = props[:disks]
         datastore_placements.delete(ds_name) if disks.empty?
       end

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/datastore.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/datastore.rb
@@ -59,6 +59,28 @@ module VSphereCloud
         end
       end
 
+      def accessible?
+        @mob.host.any? do |host_mount|
+          !host_mount.key.runtime.in_maintenance_mode
+        end
+      end
+
+      # Returns whether there is any host which can access
+      # the datastore from the cluster passed.
+      #
+      # @param [VSphereCloud::Resource::Cluster]
+      #
+      # @return [Boolean] Whether there exists a host that is not in maintenance mode and
+      # is part of the very same cluster that datastore can access
+      #
+      def accessible_from?(cluster)
+        @mob.host.any? do |host_mount_info|
+          host_mob = host_mount_info.key
+          next if host_mob.runtime.in_maintenance_mode
+          cluster.mob.host.include?(host_mob)
+        end
+      end
+
       # @return [String] debug datastore information.
       def inspect
         "<Datastore: #@mob / #@name>"

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/datastore.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/datastore.rb
@@ -74,10 +74,9 @@ module VSphereCloud
       # is part of the very same cluster that datastore can access
       #
       def accessible_from?(cluster)
-        @mob.host.any? do |host_mount_info|
-          host_mob = host_mount_info.key
-          next if host_mob.runtime.in_maintenance_mode
-          cluster.mob.host.include?(host_mob)
+        @mob.host.any? do |host_mount|
+          next if host_mount.key.runtime.in_maintenance_mode
+          cluster.mob.host.include?(host_mount.key)
         end
       end
 

--- a/src/vsphere_cpi/lib/ruby_vim_sdk/vmodl/managed_object.rb
+++ b/src/vsphere_cpi/lib/ruby_vim_sdk/vmodl/managed_object.rb
@@ -69,9 +69,11 @@ module VimSdk
         __mo_id__.hash
       end
 
-      def eql?(other)
+      def ==(other)
         @__mo_id__ == other.__mo_id__
       end
+
+      alias :eql? :==
 
     end
   end

--- a/src/vsphere_cpi/lib/ruby_vim_sdk/vmodl/managed_object.rb
+++ b/src/vsphere_cpi/lib/ruby_vim_sdk/vmodl/managed_object.rb
@@ -73,7 +73,7 @@ module VimSdk
         @__mo_id__ == other.__mo_id__
       end
 
-      alias :eql? :==
+      alias eql? ==
 
     end
   end

--- a/src/vsphere_cpi/spec/integration/host_maintenance_mode_spec.rb
+++ b/src/vsphere_cpi/spec/integration/host_maintenance_mode_spec.rb
@@ -120,7 +120,7 @@ describe 'Give a cluster with DRS On ' do
     it 'cpi should fail to create persistent disk on a datastore ' do
       begin
         expect do
-          disk_id = cpi.create_disk(2048, {}, nil)
+          cpi.create_disk(2048, {}, nil)
         end.to raise_error(/No valid placement found due to no active host/)
       end
     end

--- a/src/vsphere_cpi/spec/integration/host_maintenance_mode_spec.rb
+++ b/src/vsphere_cpi/spec/integration/host_maintenance_mode_spec.rb
@@ -39,7 +39,7 @@ describe 'Give a cluster with DRS On ' do
     before do
       turn_maintenance_on_for_half_hosts(cpi, @cluster_name_maintenance)
     end
-    it 'cpi should be able to replicate stemcell (create vm and create ephemeral disk) on a datastore accessible by non-maintenance mode host and which belongs to same cluster' do
+    it 'cpi should be able to replicate stemcell (create vm and create ephemeral disk) ' do
       begin
         @vm_id = cpi.create_vm(
           'agent-007',
@@ -56,7 +56,7 @@ describe 'Give a cluster with DRS On ' do
         delete_vm(cpi, @vm_id)
       end
     end
-    it 'cpi should be able to create persistent disk on a datastore accessible by non-maintenance mode host' do
+    it 'cpi should be able to create persistent disk ' do
       begin
         @disk_id = cpi.create_disk(2048, {}, nil)
         expect(@disk_id).to_not be_nil
@@ -103,7 +103,7 @@ describe 'Give a cluster with DRS On ' do
     before do
       turn_maintenance_on_for_all_hosts(cpi, @cluster_name_maintenance)
     end
-    it 'cpi should fail to replicate stemcell (create vm and create ephemeral disk) on a datastore accessible by all maintenance mode hosts and which belongs to same cluster' do
+    it 'cpi should fail to replicate stemcell (create vm and create ephemeral disk) on a datastore ' do
       begin
         expect do
           @vm_id = cpi.create_vm(
@@ -117,7 +117,7 @@ describe 'Give a cluster with DRS On ' do
          end.to raise_error(/No valid placement found due to no active host/)
       end
     end
-    it 'cpi should fail to create persistent disk on a datastore accessible by all maintenance mode host' do
+    it 'cpi should fail to create persistent disk on a datastore ' do
       begin
         expect do
           disk_id = cpi.create_disk(2048, {}, nil)
@@ -159,7 +159,7 @@ describe 'Give a cluster with DRS On ' do
     before do
       turn_maintenance_on_for_all_hosts(cpi, @cluster_name_maintenance)
     end
-    it 'cpi should fail to replicate stemcell (create vm and create ephemeral disk) on a datastore accessible by all maintenance mode host and which belongs to other cluster' do
+    it 'cpi should fail to replicate stemcell (create vm and create ephemeral disk) on a datastore ' do
       begin
         expect do
           @vm_id = cpi.create_vm(
@@ -173,7 +173,7 @@ describe 'Give a cluster with DRS On ' do
         end.to raise_error(/No valid placement found due to no active host/)
       end
     end
-    it 'cpi should be able to create persistent disk on a datastore accessible by all maintenance mode host' do
+    it 'cpi should be able to create persistent disk on a datastore ' do
       begin
         @disk_id = cpi.create_disk(2048, {}, nil)
         expect(@disk_id).to_not be_nil

--- a/src/vsphere_cpi/spec/integration/host_maintenance_mode_spec.rb
+++ b/src/vsphere_cpi/spec/integration/host_maintenance_mode_spec.rb
@@ -1,0 +1,192 @@
+require 'integration/spec_helper'
+
+describe 'Give a cluster with DRS On ' do
+  before (:all) do
+    @datacenter_name = fetch_and_verify_datacenter('BOSH_VSPHERE_CPI_DATACENTER')
+    # We actually use a healthy cluster but manipulate it before the test and restore after we are done
+    @cluster_name_maintenance = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_CLUSTER__MAINTENANCE_MODE_HOST')
+    @datastore_shared_pattern = fetch_and_verify_datastore('BOSH_VSPHERE_CPI_SHARED_DATASTORE_MAINTENANCE_MODE_HOST', @cluster_name_maintenance)
+    @datastore_pattern_maintenance_cluster = fetch_and_verify_datastore('BOSH_VSPHERE_CPI_DATASTORE_PATTERN_MAINTENANCE_MODE_HOST', @cluster_name_maintenance)
+  end
+
+  context 'when regex matches one or more of datastores that are accessible by one or few non-maintenace mode hosts in a cluster (datastore-*) ' do
+    let(:vm_type) do
+      {
+          'ram' => 512,
+          'disk' => 2048,
+          'cpu' => 1
+      }
+    end
+    let(:cpi) do
+      options = cpi_options(
+          'datacenters' => [
+              {
+                  'name' => @datacenter_name,
+                  'datastore_pattern' => @datastore_pattern_maintenance_cluster,
+                  'persistent_datastore_pattern' => @datastore_pattern_maintenance_cluster,
+                  'clusters' => [
+                      {
+                          @cluster_name_maintenance => {}
+                      },
+                  ]
+              }
+          ]
+      )
+      VSphereCloud::Cloud.new(options)
+    end
+
+    # We turn the maintenance mode ON for half of the hosts (rounding off to the floor) in a cluster
+    before do
+      turn_maintenance_on_for_half_hosts(cpi, @cluster_name_maintenance)
+    end
+    it 'cpi should be able to replicate stemcell (create vm and create ephemeral disk) on a datastore accessible by non-maintenance mode host and which belongs to same cluster' do
+      begin
+        @vm_id = cpi.create_vm(
+          'agent-007',
+          @stemcell_id,
+          vm_type,
+          get_network_spec,
+          [],
+          {}
+        )
+        expect(@vm_id).to_not be_nil
+        expect(cpi.has_vm?(@vm_id)).to be(true)
+        # These checks are sufficient as any try to create a vm on maintenance mode host or non-accessible host will error out.
+      ensure
+        delete_vm(cpi, @vm_id)
+      end
+    end
+    it 'cpi should be able to create persistent disk on a datastore accessible by non-maintenance mode host' do
+      begin
+        @disk_id = cpi.create_disk(2048, {}, nil)
+        expect(@disk_id).to_not be_nil
+        expect(cpi.has_disk?(@disk_id)).to be(true)
+        disk = cpi.datacenter.find_disk(VSphereCloud::DirectorDiskCID.new(@disk_id))
+        expect(disk.datastore.name).to match(@datastore_pattern_maintenance_cluster)
+      ensure
+        delete_disk(cpi, @disk_id)
+    end
+
+    end
+    after do
+      turn_maintenance_off_for_all_hosts(cpi, @cluster_name_maintenance)
+    end
+  end
+
+  context 'when regex matches one or more of datastores that are accessible by all maintenace mode hosts in a cluster (datastore-*) ' do
+    let(:vm_type) do
+      {
+          'ram' => 512,
+          'disk' => 2048,
+          'cpu' => 1
+      }
+    end
+    let(:cpi) do
+      options = cpi_options(
+          'datacenters' => [
+              {
+                  'name' => @datacenter_name,
+                  'datastore_pattern' => @datastore_pattern_maintenance_cluster,
+                  'persistent_datastore_pattern' => @datastore_pattern_maintenance_cluster,
+                  'clusters' => [
+                      {
+                          @cluster_name_maintenance => {}
+                      },
+                  ]
+              }
+          ]
+      )
+      VSphereCloud::Cloud.new(options)
+    end
+
+    # We turn the maintenance mode ON for all of the hosts (rounding off to the floor) in a cluster
+    before do
+      turn_maintenance_on_for_all_hosts(cpi, @cluster_name_maintenance)
+    end
+    it 'cpi should fail to replicate stemcell (create vm and create ephemeral disk) on a datastore accessible by all maintenance mode hosts and which belongs to same cluster' do
+      begin
+        expect do
+          @vm_id = cpi.create_vm(
+            'agent-007',
+            @stemcell_id,
+            vm_type,
+            get_network_spec,
+            [],
+            {}
+          )
+         end.to raise_error(/No valid placement found due to no active host/)
+      end
+    end
+    it 'cpi should fail to create persistent disk on a datastore accessible by all maintenance mode host' do
+      begin
+        expect do
+          disk_id = cpi.create_disk(2048, {}, nil)
+        end.to raise_error(/No valid placement found due to no active host/)
+      end
+    end
+    after do
+      turn_maintenance_off_for_all_hosts(cpi, @cluster_name_maintenance)
+    end
+  end
+
+  context 'when regex matches one or more of datastores that are accessible by all maintenace mode hosts in other cluster (datastore-*) ' do
+    let(:vm_type) do
+      {
+          'ram' => 512,
+          'disk' => 2048,
+          'cpu' => 1
+      }
+    end
+    let(:cpi) do
+      options = cpi_options(
+          'datacenters' => [
+              {
+                  'name' => @datacenter_name,
+                  'datastore_pattern' => @datastore_shared_pattern,
+                  'persistent_datastore_pattern' => @datastore_shared_pattern,
+                  'clusters' => [
+                      {
+                          @cluster_name_maintenance => {}
+                      },
+                  ]
+              }
+          ]
+      )
+      VSphereCloud::Cloud.new(options)
+    end
+
+    # We turn the maintenance mode ON for all of the hosts (rounding off to the floor) in a cluster
+    before do
+      turn_maintenance_on_for_all_hosts(cpi, @cluster_name_maintenance)
+    end
+    it 'cpi should fail to replicate stemcell (create vm and create ephemeral disk) on a datastore accessible by all maintenance mode host and which belongs to other cluster' do
+      begin
+        expect do
+          @vm_id = cpi.create_vm(
+              'agent-007',
+              @stemcell_id,
+              vm_type,
+              get_network_spec,
+              [],
+              {}
+          )
+        end.to raise_error(/No valid placement found due to no active host/)
+      end
+    end
+    it 'cpi should be able to create persistent disk on a datastore accessible by all maintenance mode host' do
+      begin
+        @disk_id = cpi.create_disk(2048, {}, nil)
+        expect(@disk_id).to_not be_nil
+        expect(cpi.has_disk?(@disk_id)).to be(true)
+        disk = cpi.datacenter.find_disk(VSphereCloud::DirectorDiskCID.new(@disk_id))
+        expect(disk.datastore.name).to match(@datastore_shared_pattern)
+      ensure
+        delete_disk(cpi, @disk_id)
+      end
+    end
+    after do
+      turn_maintenance_off_for_all_hosts(cpi, @cluster_name_maintenance)
+    end
+  end
+
+end

--- a/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
+++ b/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
@@ -408,6 +408,31 @@ module LifecycleHelpers
     all_datastore_names.select { |name| name =~ Regexp.new(pattern) }
   end
 
+  def turn_maintenance_on_for_half_hosts(cpi, cluster_name)
+    cluster = cpi.client.cloud_searcher.get_managed_object(VimSdk::Vim::ClusterComputeResource, name: cluster_name)
+    half_host_mob_array = cluster.host[0, cluster.host.length/2]
+    half_host_mob_array.each { |host_mob| host_mob.enter_maintenance_mode(0, true, nil) }
+    # Sleep for 10 seconds to allow hosts to enter maintenance mode
+    sleep 10
+  end
+
+  def turn_maintenance_off_for_all_hosts(cpi, cluster_name)
+    cluster = cpi.client.cloud_searcher.get_managed_object(VimSdk::Vim::ClusterComputeResource, name: cluster_name)
+    host_mob_array = cluster.host
+    host_mob_array.each { |host_mob| host_mob.exit_maintenance_mode(0) }
+    # Sleep for 10 seconds to allow hosts to exit maintenance mode
+    sleep 10
+  end
+
+  def turn_maintenance_on_for_all_hosts(cpi, cluster_name)
+    cluster = cpi.client.cloud_searcher.get_managed_object(VimSdk::Vim::ClusterComputeResource, name: cluster_name)
+    host_mob_array = cluster.host
+    host_mob_array.each { |host_mob| host_mob.enter_maintenance_mode(0, true, nil) }
+    # Sleep for 10 seconds to allow hosts to enter maintenance mode
+    sleep 10
+  end
+
+
   private
 
   def is_disk_in_datastores(cpi, disk_id, accessible_datastores)

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/datastore_picker_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/datastore_picker_spec.rb
@@ -114,17 +114,11 @@ module VSphereCloud
           picker.update(available_datastores)
 
           disks = [disk1, disk2]
-          expect(picker.best_disk_placement(disks)).to include({
-            datastores: {
-              'ds-1' => {
-                free_space: 512,
-                disks: [],
-              },
-              'ds-2' => {
-                free_space: 256,
-                disks: [disk1, disk2],
-              },
-            }
+          expect(picker.best_disk_placement(disks)[:datastores]).to include({
+            'ds-2' => {
+              free_space: 256,
+              disks: [disk1, disk2],
+            },
           })
         end
 
@@ -157,17 +151,15 @@ module VSphereCloud
             picker.update(available_datastores)
 
             disks = [disk1, disk2]
-            expect(picker.best_disk_placement(disks)).to include({
-              datastores: {
-                'ds-1' => {
-                  free_space: 0,
-                  disks: [disk2],
-                },
-                'ds-2' => {
-                  free_space: 768,
-                  disks: [disk1],
-                },
-              }
+            expect(picker.best_disk_placement(disks)[:datastores]).to include({
+              'ds-1' => {
+                free_space: 0,
+                disks: [disk2],
+              },
+              'ds-2' => {
+                free_space: 768,
+                disks: [disk1],
+              },
             })
           end
         end
@@ -209,8 +201,8 @@ module VSphereCloud
                   disks: [disk2],
                 },
                 'ds-2' => {
-                  free_space: 1280,
-                  disks: [disk1],
+                  free_space: 256,
+                  disks: [disk1, disk2],
                 },
               }
             })
@@ -237,17 +229,11 @@ module VSphereCloud
             picker = DatastorePicker.new(0)
             picker.update(available_datastores)
             disks = [disk1, disk2]
-            expect(picker.best_disk_placement(disks)).to include({
-              datastores: {
-                'ds-1' => {
-                  free_space: 512,
-                  disks: [],
-                },
-                'ds-2' => {
-                  free_space: 512,
-                  disks: [disk1, disk2],
-                },
-              }
+            expect(picker.best_disk_placement(disks)[:datastores]).to include({
+              'ds-2' => {
+                free_space: 512,
+                disks: [disk1, disk2],
+              },
             })
           end
         end
@@ -278,8 +264,8 @@ module VSphereCloud
               migration_size: 256,
               datastores: {
                 'ds-1' => {
-                  disks: [],
-                  free_space: 512,
+                  disks: [disk1],
+                  free_space: 256,
                 },
                 'ds-2' => {
                   disks: [disk1, disk2],
@@ -383,8 +369,8 @@ module VSphereCloud
     end
 
     describe '#pick_datastore_for_single_disk' do
-      let(:smaller_ds) { instance_double(VSphereCloud::Resources::Datastore, free_space: 256) }
-      let(:larger_ds) { instance_double(VSphereCloud::Resources::Datastore, free_space: 1024) }
+      let(:smaller_ds) { instance_double(VSphereCloud::Resources::Datastore, free_space: 256, mob: smaller_ds_mob, accessible?: true) }
+      let(:larger_ds) { instance_double(VSphereCloud::Resources::Datastore, free_space: 1024, mob: larger_ds_mob, accessible?: true) }
       let(:available_datastores) do
        {
          'smaller-ds' => smaller_ds,
@@ -398,6 +384,11 @@ module VSphereCloud
           existing_datastore_name: nil
         )
       end
+      let(:host_runtime_info) { instance_double(VimSdk::Vim::Host::RuntimeInfo, in_maintenance_mode: false) }
+      let(:host_system) {instance_double(VimSdk::Vim::HostSystem, runtime: host_runtime_info)}
+      let(:datastore_host_mount) { [instance_double('VimSdk::Vim::Datastore::HostMount', key: host_system)]}
+      let(:larger_ds_mob) { instance_double('VimSdk::Vim::Datastore', host: datastore_host_mount) }
+      let(:smaller_ds_mob) { instance_double('VimSdk::Vim::Datastore', host: datastore_host_mount) }
 
       it 'returns the picked datastore name' do
         picker = DatastorePicker.new(0)

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/datastore_picker_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/datastore_picker_spec.rb
@@ -151,16 +151,18 @@ module VSphereCloud
             picker.update(available_datastores)
 
             disks = [disk1, disk2]
-            expect(picker.best_disk_placement(disks)[:datastores]).to include({
-              'ds-1' => {
-                free_space: 0,
-                disks: [disk2],
-              },
-              'ds-2' => {
-                free_space: 768,
-                disks: [disk1],
-              },
-            })
+            expect(picker.best_disk_placement(disks)[:datastores]).to include(
+              {
+                'ds-1' => {
+                  free_space: 0,
+                  disks: [disk2]
+                },
+                'ds-2' => {
+                  free_space: 768,
+                  disks: [disk1]
+                },
+              }
+            )
           end
         end
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datastore_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datastore_spec.rb
@@ -1,60 +1,125 @@
 require 'spec_helper'
+require 'rspec/its'
 
 describe VSphereCloud::Resources::Datastore do
-  subject(:datastore) {
-    VSphereCloud::Resources::Datastore.new('foo_lun', datastore_mob,  true, 16 * 1024, 8 * 1024)
-  }
-  subject(:datastore_inaccess) {
-    VSphereCloud::Resources::Datastore.new('foo_lun', datastore_mob,  false, 16 * 1024, 8 * 1024)
-  }
+  subject do
+    described_class.new('foo_lun', mob, true, 16 * 1024, 8 * 1024)
+  end
 
-  let(:datastore_mob) { instance_double('VimSdk::Vim::Datastore', to_s: 'mob_as_string') }
+  let(:mob) do
+    instance_double('VimSdk::Vim::Datastore', to_s: 'mob_as_string')
+  end
 
   describe '#mob' do
-    it 'returns the mob' do
-      expect(datastore.mob).to eq(datastore_mob)
-    end
+    it('returns the mob') { expect(subject.mob).to eq(mob) }
   end
 
   describe '#name' do
-    it 'returns the name' do
-      expect(datastore.name).to eq('foo_lun')
+    it('returns the name') { expect(subject.name).to eq('foo_lun') }
+  end
+
+  context 'when inaccessible' do
+    subject do
+      described_class.new('foo_lun', mob, false, 16 * 1024, 8 * 1024)
     end
+
+    its(:total_space) { is_expected.to eq(0) }
+    its(:free_space) { is_expected.to eq(0) }
   end
 
   describe '#total_space' do
     it 'returns the total space' do
-      expect(datastore.total_space).to eq(16384)
-    end
-    it 'returns zero total space for inaccessible datastores' do
-      expect(datastore_inaccess.total_space).to eq(0)
+      expect(subject.total_space).to eq(16384)
     end
   end
 
   describe '#free_space' do
     it 'returns the free space' do
-      expect(datastore.free_space).to eq(8192)
+      expect(subject.free_space).to eq(8192)
     end
-    it 'returns zero free space for inaccessible datastores' do
-      expect(datastore_inaccess.free_space).to eq(0)
+  end
+
+  describe '#accessible?' do
+    before do
+      host_mount = instance_double(VimSdk::Vim::Datastore::HostMount)
+      expect(host_mount).to receive_message_chain(:key, :runtime, :in_maintenance_mode).and_return(maintenance_mode)
+      expect(mob).to receive(:host).and_return([host_mount])
+    end
+
+    context 'when all hosts are in maintenance mode' do
+      let(:maintenance_mode) { true }
+
+      it 'is false' do
+        expect(subject).to_not be_accessible
+      end
+    end
+
+    context 'when at least one of the hosts is not in maintenance mode' do
+      let(:maintenance_mode) { false }
+
+      it 'is false' do
+        expect(subject).to be_accessible
+      end
+    end
+  end
+
+  describe '#accessible_from?' do
+
+    context 'when a cluster with some hosts is defined' do
+      let (:cluster) { instance_double(VSphereCloud::Resources::Cluster) }
+      let (:host_mob) { instance_double(VimSdk::Vim::HostSystem) }
+      let (:host_mount) { instance_double(VimSdk::Vim::Datastore::HostMount, key: host_mob) }
+
+      before do
+        expect(host_mount).to receive_message_chain(:key, :runtime, :in_maintenance_mode).and_return(maintenance_mode)
+        expect(mob).to receive(:host).and_return([host_mount])
+      end
+
+      context 'when all hosts are in maintenance mode' do
+        let(:maintenance_mode) { true }
+        let(:is_included) { true }
+        it 'is false' do
+          expect(subject).to_not be_accessible_from(cluster)
+        end
+      end
+
+      context 'when at least one of the hosts is not in maintenance mode' do
+        before do
+          expect(cluster).to receive_message_chain(:mob, :host, :include?).with(host_mob).and_return(is_included)
+        end
+        let(:maintenance_mode) { false }
+
+        context 'when all hosts do not belong to the cluster' do
+          let(:is_included) { false }
+          it 'is false' do
+            expect(subject).to_not be_accessible_from(cluster)
+          end
+        end
+        context 'when at least one of the host belong to the cluster' do
+          let(:is_included) { true }
+          it 'is true' do
+            expect(subject).to be_accessible_from(cluster)
+          end
+        end
+      end
     end
   end
 
   describe '#inspect' do
     it 'returns the printable form' do
-      expect(datastore.inspect).to eq("<Datastore: #{datastore_mob} / foo_lun>")
+      expect(subject.inspect).to eq("<Datastore: #{mob} / foo_lun>")
     end
   end
 
   describe '#debug_info' do
     it 'returns the disk space info' do
-      expect(datastore.debug_info).to eq("foo_lun (8192MB free of 16384MB capacity)")
+      expect(subject.debug_info).to eq('foo_lun (8192MB free of 16384MB capacity)')
     end
   end
 
   describe '#to_s' do
     it 'show relevant info' do
-      expect(datastore.to_s).to eq("(#{datastore.class.name} (name=\"foo_lun\", mob=\"mob_as_string\"))")
+      expect(subject.to_s).to eq(%Q[(#{described_class.name} (name="foo_lun", mob="mob_as_string"))])
     end
   end
 end


### PR DESCRIPTION
Add support for host under maintenance mode
Add unit test for host in maintenance mode changes.
Refactor picker code and datastore(Resource) class
Add == operator to managed object class.

Passes all unit and integrations test.