### PR TITLE
Update nokogiri to 1.8.1 to fix critical severity security vulnerability

### DIFF
--- a/src/vsphere_cpi/Gemfile
+++ b/src/vsphere_cpi/Gemfile
@@ -4,7 +4,7 @@ gem 'bosh_common', '1.3262.24.0'
 gem 'bosh_cpi',    '2.4.1'
 gem 'membrane',    '~>1.1.0'
 gem 'builder',     '~>3.2.3'
-gem 'nokogiri',    '~>1.7.1'
+gem 'nokogiri',    '~>1.8.1'
 gem 'mono_logger', '~>1.1.0'
 gem 'oga', '2.3'
 

--- a/src/vsphere_cpi/Gemfile.lock
+++ b/src/vsphere_cpi/Gemfile.lock
@@ -23,11 +23,11 @@ GEM
       multi_json (>= 1.8.4)
     membrane (1.1.0)
     method_source (0.8.2)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     mono_logger (1.1.0)
     multi_json (1.12.1)
-    nokogiri (1.7.2)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     oga (2.3)
       ast
       ruby-ll (~> 2.1)
@@ -83,7 +83,7 @@ DEPENDENCIES
   fakefs
   membrane (~> 1.1.0)
   mono_logger (~> 1.1.0)
-  nokogiri (~> 1.7.1)
+  nokogiri (~> 1.8.1)
   oga (= 2.3)
   parallel_tests
   pry
@@ -97,4 +97,4 @@ DEPENDENCIES
   timecop (~> 0.8.1)
 
 BUNDLED WITH
-   1.15.3
+   1.16.0


### PR DESCRIPTION
[#154948249](https://www.pivotaltracker.com/story/show/154948249)