### PR TITLE
 Upgrade virtual hardware for a vm

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -181,6 +181,10 @@ module VSphereCloud
         @client.power_on_vm(datacenter_mob, @mob)
       end
 
+      def upgrade_vm_virtual_hardware
+        @client.upgrade_vm_virtual_hardware(@mob)
+      end
+
       def delete
         @client.delete_vm(@mob)
       end

--- a/src/vsphere_cpi/lib/cloud/vsphere/sdk_helpers/retry_judge.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/sdk_helpers/retry_judge.rb
@@ -40,6 +40,11 @@ module VSphereCloud
           # sometimes called to confirm a disk does not exist
           method_name: 'SearchDatastore_Task',
           fault_class: VimSdk::Vim::Fault::FileNotFound,
+        },
+        {
+          # called to upgrade a vm
+          method_name: 'UpgradeVM_Task',
+          fault_class: VimSdk::Vim::Fault::AlreadyUpgraded,
         }
       ]
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/task_runner.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/task_runner.rb
@@ -81,6 +81,7 @@ module VSphereCloud
       exceptions_by_fault = {
         VimSdk::Vim::Fault::FileNotFound => VCenterClient::FileNotFoundException,
         VimSdk::Vim::Fault::DuplicateName => VCenterClient::DuplicateName,
+        VimSdk::Vim::Fault::AlreadyUpgraded => VCenterClient::AlreadyUpgraded,
       }
       exceptions_by_fault.fetch(fault.class, VCenterClient::TaskException).new(fault.msg)
     end

--- a/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
@@ -5,6 +5,7 @@ module VSphereCloud
     class TaskException < StandardError; end
     class FileNotFoundException < TaskException; end
     class DuplicateName < TaskException; end
+    class AlreadyUpgraded < TaskException; end
     class AlreadyLoggedInException < StandardError; end
     class NotLoggedInException < StandardError; end
 
@@ -73,6 +74,13 @@ module VSphereCloud
 
     def answer_vm(vm, question, answer)
       vm.answer(question, answer)
+    end
+
+    def upgrade_vm_virtual_hardware(vm)
+      @logger.info("Upgrading virtual hardware on VM")
+      wait_for_task do
+        vm.upgrade_virtual_hardware
+      end
     end
 
     def power_on_vm(datacenter, vm)

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -123,6 +123,12 @@ module VSphereCloud
         # DRS Rules
         create_drs_rules(vm_config, created_vm.mob, cluster)
 
+        begin
+          # Upgrade to latest virtual hardware version
+          created_vm.upgrade_vm_virtual_hardware if vm_config.vm_type.upgrade_hw_version
+        rescue VSphereCloud::VCenterClient::AlreadyUpgraded
+        end
+
         # Power on VM
         @logger.info("Powering on VM: #{created_vm}")
         created_vm.power_on

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
@@ -12,7 +12,7 @@ module VSphereCloud
       @cloud_properties = cloud_properties
     end
 
-    %w[cpu ram disk cpu_hot_add_enabled memory_hot_add_enabled nsx vmx_options nsxt nested_hardware_virtualization datacenters ].each do |name|
+    %w[cpu ram disk cpu_hot_add_enabled memory_hot_add_enabled nsx vmx_options nsxt nested_hardware_virtualization upgrade_hw_version datacenters ].each do |name|
       define_method(name) { @cloud_properties[name] }
     end
 

--- a/src/vsphere_cpi/lib/ruby_vim_sdk/method.rb
+++ b/src/vsphere_cpi/lib/ruby_vim_sdk/method.rb
@@ -32,6 +32,11 @@ module VimSdk
     def result_type_optional?
       @result_type_optional
     end
+
+    def num_optional_args
+      return @num_optional_args_at_end if @num_optional_args_at_end
+      @num_optional_args_at_end = @arguments.reverse.take_while(&:optional?).length
+    end
   end
 
 end

--- a/src/vsphere_cpi/lib/ruby_vim_sdk/vmodl/managed_object.rb
+++ b/src/vsphere_cpi/lib/ruby_vim_sdk/vmodl/managed_object.rb
@@ -39,8 +39,9 @@ module VimSdk
             end
             self.instance_eval do
               define_method(method.name) do |*args|
-                if args.length != method.arguments.length
-                  raise ArgumentError, "wrong number of arguments (#{args.length} for #{method.arguments.length})"
+                if (args.length < (method.arguments.length - method.num_optional_args)) ||
+                  (args.length > method.arguments.length)
+                  raise ArgumentError, "wrong number of arguments (#{args.length} for #{method.arguments.length} with optional args #{method.number_of_optional_args_in_end})"
                 end
                 self.class.invoke_method(self, method, *args)
               end

--- a/src/vsphere_cpi/lib/ruby_vim_sdk/vmodl/managed_object.rb
+++ b/src/vsphere_cpi/lib/ruby_vim_sdk/vmodl/managed_object.rb
@@ -39,8 +39,7 @@ module VimSdk
             end
             self.instance_eval do
               define_method(method.name) do |*args|
-                if (args.length < (method.arguments.length - method.num_optional_args)) ||
-                  (args.length > method.arguments.length)
+                unless args.length.between?(method.arguments.length - method.num_optional_args, method.arguments.length)
                   raise ArgumentError, "wrong number of arguments (#{args.length} for #{method.arguments.length} with optional args #{method.number_of_optional_args_in_end})"
                 end
                 self.class.invoke_method(self, method, *args)

--- a/src/vsphere_cpi/spec/integration/upgrade_vm_virtual_hw_spec.rb
+++ b/src/vsphere_cpi/spec/integration/upgrade_vm_virtual_hw_spec.rb
@@ -1,0 +1,22 @@
+require 'integration/spec_helper'
+
+context 'when upgrade_hw_version is enabled' do
+
+  let(:vm_type) do
+    {
+      'ram' => 512,
+      'disk' => 2048,
+      'cpu' => 1,
+      'upgrade_hw_version' => true
+
+    }
+  end
+
+  it 'creates a VM with those properties enabled' do
+    simple_vm_lifecycle(@cpi, @vlan, vm_type) do |vm_id|
+      vm = @cpi.vm_provider.find(vm_id)
+      vm_mob = vm.mob
+      expect(vm_mob.config.version).to match /vmx-1./
+    end
+  end
+end


### PR DESCRIPTION
Upgrade virtual hardware if config option provided by user.
  - Limits error and number of retries in case vm is already upgraded 

Account for optional arguments while verifying method args (vim sdk methods)