### PR TITLE
Make logger a singleton

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/agent_env.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/agent_env.rb
@@ -3,7 +3,7 @@ require 'cloud/vsphere/logger'
 module VSphereCloud
   class AgentEnv
     include VimSdk
-    extend Logger
+    include Logger
 
     def initialize(client:, file_provider:, cloud_searcher:)
       @client = client

--- a/src/vsphere_cpi/lib/cloud/vsphere/agent_env.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/agent_env.rb
@@ -1,16 +1,18 @@
+require 'cloud/vsphere/logger'
+
 module VSphereCloud
   class AgentEnv
     include VimSdk
+    extend Logger
 
-    def initialize(client:, file_provider:, cloud_searcher:, logger:)
+    def initialize(client:, file_provider:, cloud_searcher:)
       @client = client
       @file_provider = file_provider
       @cloud_searcher = cloud_searcher
-      @logger = logger
     end
 
     def get_current_env(vm, datacenter_name)
-      @logger.info("Getting current agent env from vm '#{vm.name}' in datacenter '#{datacenter_name}'")
+      logger.info("Getting current agent env from vm '#{vm.name}' in datacenter '#{datacenter_name}'")
       cdrom = @client.get_cdrom_device(vm)
       env_iso_folder = env_iso_folder(cdrom)
       return unless env_iso_folder
@@ -28,7 +30,7 @@ module VSphereCloud
     end
 
     def set_env(vm, location, env)
-      @logger.info("Updating current agent env from vm '#{vm.name}' in datacenter '#{location[:datacenter]}'")
+      logger.info("Updating current agent env from vm '#{vm.name}' in datacenter '#{location[:datacenter]}'")
       env_json = JSON.dump(env)
 
       disconnect_cdrom(vm)
@@ -48,7 +50,7 @@ module VSphereCloud
     end
 
     def clean_env(vm)
-      @logger.info("Cleaning current agent env from vm '#{vm.name}'")
+      logger.info("Cleaning current agent env from vm '#{vm.name}'")
       cdrom = @client.get_cdrom_device(vm)
       env_iso_folder = env_iso_folder(cdrom)
       return unless env_iso_folder

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -26,7 +26,7 @@ module VSphereCloud
         vcenter_api_uri: @config.vcenter_api_uri,
         http_client: http_client
       )
-      def other_client.logger
+      other_client.define_singleton_method(:logger) do
         @logger ||= ::Logger.new('/dev/null')
       end
       other_client.login(@config.vcenter_user, @config.vcenter_password, 'en')

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -6,7 +6,7 @@ require 'cloud'
 module VSphereCloud
   class Cloud < Bosh::Cloud
     include VimSdk
-    extend Logger
+    include Logger
 
     class TimeoutException < StandardError; end
     class NetworkException < StandardError

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -1,3 +1,4 @@
+require 'cloud/vsphere/logger'
 require 'json'
 require 'membrane'
 require 'cloud'
@@ -5,6 +6,7 @@ require 'cloud'
 module VSphereCloud
   class Cloud < Bosh::Cloud
     include VimSdk
+    extend Logger
 
     class TimeoutException < StandardError; end
     class NetworkException < StandardError
@@ -15,16 +17,18 @@ module VSphereCloud
       end
     end
 
-    attr_accessor :client, :logger # exposed for testing
+    attr_accessor :client
     attr_reader :config, :datacenter, :heartbeat_thread
 
     def enable_telemetry
       http_client = VSphereCloud::CpiHttpClient.new
       other_client = VCenterClient.new(
         vcenter_api_uri: @config.vcenter_api_uri,
-        http_client: http_client,
-        logger: Logger.new('/dev/null'),
+        http_client: http_client
       )
+      def other_client.logger
+        @logger ||= ::Logger.new('/dev/null')
+      end
       other_client.login(@config.vcenter_user, @config.vcenter_password, 'en')
       option = Vim::Option::OptionValue.new
       option.key = 'config.SDDC.cpi'
@@ -40,27 +44,24 @@ module VSphereCloud
     def initialize(options)
       @config = Config.build(options)
 
-      @logger = config.logger
+      Logger.logger = config.logger
 
-      request_id = options['vcenters'][0]['request_id']
-      if request_id
-        @logger.set_request_id(request_id)
+      if request_id = options['vcenters'][0]['request_id']
+        Logger.logger.set_request_id(request_id)
       end
 
       @http_client = VSphereCloud::CpiHttpClient.new(@config.soap_log)
 
       @client = VCenterClient.new(
         vcenter_api_uri: @config.vcenter_api_uri,
-        http_client: @http_client,
-        logger: @logger,
+        http_client: @http_client
       )
       @client.login(@config.vcenter_user, @config.vcenter_password, 'en')
 
-      @cloud_searcher = CloudSearcher.new(@client.service_content, @logger)
+      @cloud_searcher = CloudSearcher.new(@client.service_content)
       @cluster_provider = Resources::ClusterProvider.new(
         datacenter_name: @config.datacenter_name,
-        client: @client,
-        logger: @logger,
+        client: @client
       )
       @datacenter = Resources::Datacenter.new(
         client: @client,
@@ -72,23 +73,20 @@ module VSphereCloud
         name: @config.datacenter_name,
         disk_path: @config.datacenter_disk_path,
         clusters: @config.datacenter_clusters,
-        cluster_provider: @cluster_provider,
-        logger: @logger,
+        cluster_provider: @cluster_provider
       )
       @file_provider = FileProvider.new(
         http_client: @http_client,
-        vcenter_host: @config.vcenter_host,
-        logger: @logger
+        vcenter_host: @config.vcenter_host
       )
       @agent_env = AgentEnv.new(
         client: client,
         file_provider: @file_provider,
-        cloud_searcher: @cloud_searcher,
-        logger: @logger,
+        cloud_searcher: @cloud_searcher
       )
 
       # Setup NSX-T Provider
-      @nsxt_provider = NSXTProvider.new(@config.nsxt, @logger) if @config.nsxt_enabled?
+      @nsxt_provider = NSXTProvider.new(@config.nsxt) if @config.nsxt_enabled?
 
       # We get disconnected if the connection is inactive for a long period.
       @heartbeat_thread = Thread.new do
@@ -132,7 +130,7 @@ module VSphereCloud
         telemetry_thread = Thread.new { enable_telemetry }
         result = nil
         Dir.mktmpdir do |temp_dir|
-          @logger.info("Extracting stemcell to: #{temp_dir}")
+          logger.info("Extracting stemcell to: #{temp_dir}")
           output = `tar -C #{temp_dir} -xzf #{image} 2>&1`
           raise "Corrupt image '#{image}', tar exit status: #{$?.exitstatus}, output: #{output}" if $?.exitstatus != 0
 
@@ -141,7 +139,7 @@ module VSphereCloud
           ovf_file = File.join(temp_dir, ovf_file)
 
           name = "sc-#{SecureRandom.uuid}"
-          @logger.info("Generated name: #{name}")
+          logger.info("Generated name: #{name}")
 
           stemcell_size = File.size(image) / (1024 * 1024)
           vm_type = VmType.new(@datacenter, {'ram' => 0})
@@ -166,7 +164,7 @@ module VSphereCloud
           cluster = vm_config.cluster
           datastore = @datacenter.find_datastore(datastore_name)
 
-          @logger.info("Deploying to: #{cluster.mob} / #{datastore.mob}")
+          logger.info("Deploying to: #{cluster.mob} / #{datastore.mob}")
 
           import_spec_result = import_ovf(name, ovf_file, cluster.resource_pool.mob, datastore.mob)
 
@@ -175,18 +173,18 @@ module VSphereCloud
           end.device
           system_disk.backing.thin_provisioned = @config.vcenter_default_disk_type == 'thin'
 
-          lease_obtainer = LeaseObtainer.new(@cloud_searcher, @logger)
+          lease_obtainer = LeaseObtainer.new(@cloud_searcher)
           nfc_lease = lease_obtainer.obtain(
             cluster.resource_pool,
             import_spec_result.import_spec,
             @datacenter.template_folder,
           )
 
-          @logger.info('Uploading')
+          logger.info('Uploading')
           vm = upload_ovf(ovf_file, nfc_lease, import_spec_result.file_item)
           result = name
 
-          @logger.info('Removing NICs')
+          logger.info('Removing NICs')
           devices = @cloud_searcher.get_property(vm, Vim::VirtualMachine, 'config.hardware.device', ensure_all: true)
           config = Vim::Vm::ConfigSpec.new
           config.device_change = []
@@ -198,7 +196,7 @@ module VSphereCloud
           end
           client.reconfig_vm(vm, config)
 
-          @logger.info('Taking initial snapshot')
+          logger.info('Taking initial snapshot')
 
           # Despite the naming, this has nothing to do with the Cloud notion of a disk snapshot
           # (which comes from AWS). This is a vm snapshot.
@@ -214,17 +212,17 @@ module VSphereCloud
 
     def delete_stemcell(stemcell)
       with_thread_name("delete_stemcell(#{stemcell})") do
-        Bosh::ThreadPool.new(max_threads: 32, logger: @logger).wrap do |pool|
-          @logger.info("Looking for stemcell replicas in: #{@datacenter.name}")
+        Bosh::ThreadPool.new(max_threads: 32, logger: logger).wrap do |pool|
+          logger.info("Looking for stemcell replicas in: #{@datacenter.name}")
           matches = client.find_all_stemcell_replicas(@datacenter.mob, stemcell)
 
           matches.each do |sc|
             sc_name = sc.name
-            @logger.info("Found: #{sc_name}")
+            logger.info("Found: #{sc_name}")
             pool.process do
-              @logger.info("Deleting: #{sc_name}")
+              logger.info("Deleting: #{sc_name}")
               client.delete_vm(sc)
-              @logger.info("Deleted: #{sc_name}")
+              logger.info("Deleted: #{sc_name}")
             end
           end
 
@@ -282,19 +280,18 @@ module VSphereCloud
           vm_creator = VmCreator.new(
             client: @client,
             cloud_searcher: @cloud_searcher,
-            logger: @logger,
             cpi: self,
             datacenter: @datacenter,
             agent_env: @agent_env,
-            ip_conflict_detector: IPConflictDetector.new(@logger, @client),
+            ip_conflict_detector: IPConflictDetector.new(@client),
             default_disk_type: @config.vcenter_default_disk_type,
             enable_auto_anti_affinity_drs_rules: @config.vcenter_enable_auto_anti_affinity_drs_rules,
-            stemcell: Stemcell.new(stemcell_cid, @logger),
+            stemcell: Stemcell.new(stemcell_cid),
             upgrade_hw_version: @config.upgrade_hw_version
           )
           created_vm = vm_creator.create(vm_config)
         rescue => e
-          @logger.error("Error in creating vm: #{e}, Backtrace - #{e.backtrace.join("\n")}")
+          logger.error("Error in creating vm: #{e}, Backtrace - #{e.backtrace.join("\n")}")
           raise e
         end
 
@@ -306,7 +303,7 @@ module VSphereCloud
               #For dynamic server pools add vm to the corresponding nsgroup
               static_server_pools, dynamic_server_pools = @nsxt_provider.retrieve_server_pools(vm_type.nsxt_server_pools)
               lb_ns_groups = dynamic_server_pools.map{ |server_pool| server_pool.member_group.grouping_object.target_display_name } if dynamic_server_pools
-              @logger.info("NSGroup names corresponding to load balancer's dynamic server pools are: #{lb_ns_groups}")
+              logger.info("NSGroup names corresponding to load balancer's dynamic server pools are: #{lb_ns_groups}")
               ns_groups.concat(lb_ns_groups) if lb_ns_groups
               @nsxt_provider.add_vm_to_server_pools(created_vm, static_server_pools) if static_server_pools
             end
@@ -314,12 +311,12 @@ module VSphereCloud
             @nsxt_provider.set_vif_type(created_vm, vm_type.nsxt)
           end
         rescue => e
-          @logger.info("Failed to apply NSX properties to VM '#{created_vm.cid}' with error: #{e.message}")
+          logger.info("Failed to apply NSX properties to VM '#{created_vm.cid}' with error: #{e.message}")
           begin
-            @logger.info("Deleting VM '#{created_vm.cid}'...")
+            logger.info("Deleting VM '#{created_vm.cid}'...")
             delete_vm(created_vm.cid)
           rescue => ex
-            @logger.info("Failed to delete VM '#{created_vm.cid}' with message: #{ex.inspect}")
+            logger.info("Failed to delete VM '#{created_vm.cid}' with message: #{ex.inspect}")
           end
           raise e
         end
@@ -343,12 +340,12 @@ module VSphereCloud
             nsx.add_members_to_lbs(vm_type.nsx_lbs)
           end
         rescue => e
-          @logger.info("Failed to apply NSX properties to VM '#{created_vm.cid}' with error: #{e}")
+          logger.info("Failed to apply NSX properties to VM '#{created_vm.cid}' with error: #{e}")
           begin
-            @logger.info("Deleting VM '#{created_vm.cid}'...")
+            logger.info("Deleting VM '#{created_vm.cid}'...")
             delete_vm(created_vm.cid)
           rescue => ex
-            @logger.info("Failed to delete vm '#{created_vm.cid}' with message:  #{ex.inspect}")
+            logger.info("Failed to delete vm '#{created_vm.cid}' with message:  #{ex.inspect}")
           end
           raise e
         end
@@ -367,7 +364,8 @@ module VSphereCloud
 
     def delete_vm(vm_cid)
       with_thread_name("delete_vm(#{vm_cid})") do
-        @logger.info("Deleting vm: #{vm_cid}")
+        logger.info("Deleting vm: #{vm_cid}")
+
         vm = vm_provider.find(vm_cid)
         vm_ip = vm.mob.guest&.ip_address
         vm.power_off
@@ -384,17 +382,17 @@ module VSphereCloud
           begin
             @nsxt_provider.remove_vm_from_nsgroups(vm)
           rescue => e
-            @logger.info("Failed to remove VM from NSGroups: #{e.message}")
+            logger.info("Failed to remove VM from NSGroups: #{e.message}")
           end
           begin
             @nsxt_provider.remove_vm_from_server_pools(vm_ip)
           rescue => e
-            @logger.info("Failed to remove VM from ServerPool: #{e.message}")
+            logger.info("Failed to remove VM from ServerPool: #{e.message}")
           end
         end
 
         vm.delete
-        @logger.info("Deleted vm: #{vm_cid}")
+        logger.info("Deleted vm: #{vm_cid}")
       end
     end
 
@@ -402,17 +400,17 @@ module VSphereCloud
       with_thread_name("reboot_vm(#{vm_cid})") do
         vm = vm_provider.find(vm_cid)
 
-        @logger.info("Reboot vm = #{vm_cid}")
+        logger.info("Reboot vm = #{vm_cid}")
 
         unless vm.powered_on?
-          @logger.info("VM not in POWERED_ON state. Current state : #{vm.power_state}")
+          logger.info("VM not in POWERED_ON state. Current state : #{vm.power_state}")
         end
 
         begin
           vm.reboot
         rescue => e
-          @logger.error("Soft reboot failed #{e} -#{e.backtrace.join("\n")}")
-          @logger.info('Try hard reboot')
+          logger.error("Soft reboot failed #{e} -#{e.backtrace.join("\n")}")
+          logger.info('Try hard reboot')
 
           # if we fail to perform a soft-reboot we force a hard-reboot
           vm.power_off if vm.powered_on?
@@ -485,7 +483,7 @@ module VSphereCloud
       with_thread_name("detach_disk(#{vm_cid}, #{raw_director_disk_cid})") do
         director_disk_cid = DirectorDiskCID.new(raw_director_disk_cid)
 
-        @logger.info("Detaching disk: #{director_disk_cid.value} from vm: #{vm_cid}")
+        logger.info("Detaching disk: #{director_disk_cid.value} from vm: #{vm_cid}")
 
         vm = vm_provider.find(vm_cid)
         disk = vm.disk_by_cid(director_disk_cid.value)
@@ -498,7 +496,7 @@ module VSphereCloud
 
     def create_disk(size_in_mb, cloud_properties, vm_cid = nil)
       with_thread_name("create_disk(#{size_in_mb}, _)") do
-        @logger.info("Creating disk with size: #{size_in_mb}")
+        logger.info("Creating disk with size: #{size_in_mb}")
         if vm_cid
           vm = vm_provider.find(vm_cid)
           accessible_datastores = vm.accessible_datastores
@@ -506,8 +504,8 @@ module VSphereCloud
           accessible_datastores = @datacenter.accessible_datastores
         end
 
-        disk_pool = DiskPool.new(@datacenter,  cloud_properties['datastores'])
-        target_datastore_pattern = StoragePicker.choose_persistent_pattern(disk_pool, @logger)
+        disk_pool = DiskPool.new(@datacenter, cloud_properties['datastores'])
+        target_datastore_pattern = StoragePicker.choose_persistent_pattern(disk_pool)
         datastore_name = StoragePicker.choose_persistent_storage(size_in_mb, target_datastore_pattern, accessible_datastores)
 
         if vm_cid
@@ -519,12 +517,11 @@ module VSphereCloud
           datastore = @datacenter.find_datastore(datastore_name)
         end
 
-
-        @logger.info("Using datastore #{datastore.name} to store persistent disk")
+        logger.info("Using datastore #{datastore.name} to store persistent disk")
 
         disk_type = cloud_properties.fetch('type', @config.vcenter_default_disk_type)
         disk = @datacenter.create_disk(datastore, size_in_mb, disk_type)
-        @logger.info("Created disk: #{disk.inspect}")
+        logger.info("Created disk: #{disk.inspect}")
 
         disk_pool.storage_list.any? ? DirectorDiskCID.encode(disk.cid, target_datastore_pattern: target_datastore_pattern) : disk.cid
       end
@@ -533,11 +530,11 @@ module VSphereCloud
     def delete_disk(raw_director_disk_cid)
       with_thread_name("delete_disk(#{raw_director_disk_cid})") do
         director_disk_cid = DirectorDiskCID.new(raw_director_disk_cid)
-        @logger.info("Deleting disk: #{director_disk_cid.value}")
+        logger.info("Deleting disk: #{director_disk_cid.value}")
         disk = @datacenter.find_disk(director_disk_cid)
         client.delete_disk(@datacenter.mob, disk.path)
 
-        @logger.info('Finished deleting disk')
+        logger.info('Finished deleting disk')
       end
     end
 
@@ -617,14 +614,14 @@ module VSphereCloud
     def get_vms
       subfolders = []
       with_thread_name('get_vms') do
-        @logger.info("Looking for VMs in: #{@datacenter.name} - #{@datacenter.master_vm_folder.path}")
+        logger.info("Looking for VMs in: #{@datacenter.name} - #{@datacenter.master_vm_folder.path}")
         subfolders += @datacenter.master_vm_folder.mob.child_entity
-        @logger.info("Looking for Stemcells in: #{@datacenter.name} - #{@datacenter.master_template_folder.path}")
+        logger.info("Looking for Stemcells in: #{@datacenter.name} - #{@datacenter.master_template_folder.path}")
         subfolders += @datacenter.master_template_folder.mob.child_entity
       end
       mobs = subfolders.map { |folder| folder.child_entity }.flatten
       mobs.map do |mob|
-        VSphereCloud::Resources::VM.new(mob.name, mob, @client, @logger)
+        VSphereCloud::Resources::VM.new(mob.name, mob, @client)
       end
     end
 
@@ -633,11 +630,7 @@ module VSphereCloud
     end
 
     def vm_provider
-      VMProvider.new(
-        @datacenter,
-        @client,
-        @logger
-      )
+      VMProvider.new(@datacenter, @client)
     end
 
     def nsx
@@ -650,7 +643,7 @@ module VSphereCloud
         @config.nsx_password,
         @config.soap_log,
       )
-      @nsx = NSX.new(@config.nsx_url, nsx_http_client, @logger)
+      @nsx = NSX.new(@config.nsx_url, nsx_http_client)
     end
 
     def cleanup
@@ -700,7 +693,7 @@ module VSphereCloud
               end
             end
 
-            @logger.info("Uploading disk to: #{device_url.url}")
+            logger.info("Uploading disk to: #{device_url.url}")
 
             @file_provider.upload_file_to_url(device_url.url,
                              disk_file,
@@ -760,7 +753,7 @@ module VSphereCloud
         )
       end
       #ephemeral disk configuration
-      ephemeral_pattern = StoragePicker.choose_ephemeral_pattern(vm_type, @logger)
+      ephemeral_pattern = StoragePicker.choose_ephemeral_pattern(vm_type)
       ephemeral_disk_config = VSphereCloud::DiskConfig.new(
         size: vm_type.disk,
         ephemeral: true,

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud_searcher.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud_searcher.rb
@@ -8,9 +8,8 @@ module VSphereCloud
 
     PC = Vmodl::Query::PropertyCollector
 
-    def initialize(service_content, logger)
+    def initialize(service_content)
       @service_content = service_content
-      @logger = logger
     end
 
     def get_property(obj, type, property, options = {})

--- a/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/drs_lock.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/drs_lock.rb
@@ -2,7 +2,7 @@ require 'cloud/vsphere/logger'
 
 module VSphereCloud
   class DrsLock
-    extend Logger
+    include Logger
 
     DRS_LOCK_NAME = 'drs_lock'
     MAX_LOCK_TIMEOUT_IN_SECONDS = 30

--- a/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/drs_lock.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/drs_lock.rb
@@ -1,5 +1,8 @@
+require 'cloud/vsphere/logger'
+
 module VSphereCloud
   class DrsLock
+    extend Logger
 
     DRS_LOCK_NAME = 'drs_lock'
     MAX_LOCK_TIMEOUT_IN_SECONDS = 30
@@ -7,19 +10,18 @@ module VSphereCloud
     class LockError < RuntimeError; end
     class TimeoutError < RuntimeError; end
 
-    def initialize(vm_attribute_manager, logger)
+    def initialize(vm_attribute_manager)
       @vm_attribute_manager = vm_attribute_manager
-      @logger = logger
     end
 
     def with_drs_lock
       acquire_lock
-      @logger.debug('Acquired drs lock')
+      logger.debug('Acquired drs lock')
       # Ensure to release the lock only after it is successfully acquired
       begin
         yield
       ensure
-        @logger.debug('Releasing drs lock')
+        logger.debug('Releasing drs lock')
         release_lock
       end
     end
@@ -33,7 +35,7 @@ module VSphereCloud
         @vm_attribute_manager.create(DRS_LOCK_NAME)
       end
     rescue TimeoutError
-      @logger.debug('Failed to acquire drs lock')
+      logger.debug('Failed to acquire drs lock')
       raise LockError.new('Failed to acquire DRS lock')
     end
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/drs_rule.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/drs_rule.rb
@@ -1,24 +1,26 @@
+require 'cloud/vsphere/logger'
+
 module VSphereCloud
   class DrsRule
+    extend Logger
+
     CUSTOM_ATTRIBUTE_NAME = 'drs_rule'
 
-    def initialize(rule_name, client, cloud_searcher, datacenter_cluster, logger)
+    def initialize(rule_name, client, cloud_searcher, datacenter_cluster)
       @rule_name = rule_name
       @client = client
       @cloud_searcher = cloud_searcher
       @datacenter_cluster = datacenter_cluster
-      @logger = logger
 
       @vm_attribute_manager = VMAttributeManager.new(
-        client.service_content.custom_fields_manager,
-        @logger
+        client.service_content.custom_fields_manager
       )
     end
 
     def add_vm(vm)
       tag_vm(vm)
 
-      DrsLock.new(@vm_attribute_manager, @logger).with_drs_lock do
+      DrsLock.new(@vm_attribute_manager).with_drs_lock do
         rule = find_rule
         if rule
           update_rule(rule.key)
@@ -33,11 +35,11 @@ module VSphereCloud
     def tag_vm(vm)
       custom_attribute = @vm_attribute_manager.find_by_name(CUSTOM_ATTRIBUTE_NAME)
       unless custom_attribute
-        @logger.debug('Creating DRS rule attribute')
+        logger.debug('Creating DRS rule attribute')
         @vm_attribute_manager.create(CUSTOM_ATTRIBUTE_NAME)
       end
 
-      @logger.debug("Updating DRS rule attribute value: #{@rule_name}, vm: #{vm.name}")
+      logger.debug("Updating DRS rule attribute value: #{@rule_name}, vm: #{vm.name}")
       vm.set_custom_value(CUSTOM_ATTRIBUTE_NAME, @rule_name)
     end
 
@@ -46,12 +48,12 @@ module VSphereCloud
     end
 
     def add_rule
-      @logger.debug("Adding DRS rule: #{@rule_name}")
+      logger.debug("Adding DRS rule: #{@rule_name}")
       reconfigure_cluster('add')
     end
 
     def update_rule(rule_key)
-      @logger.debug("Updating DRS rule: #{@rule_name}")
+      logger.debug("Updating DRS rule: #{@rule_name}")
       reconfigure_cluster('edit', rule_key)
     end
 
@@ -65,7 +67,7 @@ module VSphereCloud
       rule_info.name = @rule_name
       rule_info.vm = tagged_vms
       vm_names = rule_info.vm.map { |v| v.name }
-      @logger.debug("Setting DRS rule: #{@rule_name}, vms: #{vm_names.join(', ')}")
+      logger.debug("Setting DRS rule: #{@rule_name}, vms: #{vm_names.join(', ')}")
       rule_info.key = rule_key if rule_key
 
       rule_spec.info = rule_info

--- a/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/drs_rule.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/drs_rule.rb
@@ -2,7 +2,7 @@ require 'cloud/vsphere/logger'
 
 module VSphereCloud
   class DrsRule
-    extend Logger
+    include Logger
 
     CUSTOM_ATTRIBUTE_NAME = 'drs_rule'
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/vm_attribute_manager.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/vm_attribute_manager.rb
@@ -1,8 +1,11 @@
+require 'cloud/vsphere/logger'
+
 module VSphereCloud
   class VMAttributeManager
-    def initialize(custom_fields_manager, logger)
+    extend Logger
+
+    def initialize(custom_fields_manager)
       @custom_fields_manager = custom_fields_manager
-      @logger = logger
     end
 
     def find_by_name(name)
@@ -10,7 +13,7 @@ module VSphereCloud
     end
 
     def create(name)
-      @logger.debug("Creating DRS rule attribute: #{name}")
+      logger.debug("Creating DRS rule attribute: #{name}")
       @custom_fields_manager.add_field_definition(
         name,
         VimSdk::Vim::VirtualMachine,
@@ -20,7 +23,7 @@ module VSphereCloud
     end
 
     def delete(name)
-      @logger.debug("Deleting DRS rule attribute: #{name}")
+      logger.debug("Deleting DRS rule attribute: #{name}")
       custom_field = find_by_name(name)
       @custom_fields_manager.remove_field_definition(custom_field.key) if custom_field
     end

--- a/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/vm_attribute_manager.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/vm_attribute_manager.rb
@@ -2,7 +2,7 @@ require 'cloud/vsphere/logger'
 
 module VSphereCloud
   class VMAttributeManager
-    extend Logger
+    include Logger
 
     def initialize(custom_fields_manager)
       @custom_fields_manager = custom_fields_manager

--- a/src/vsphere_cpi/lib/cloud/vsphere/file_provider.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/file_provider.rb
@@ -2,7 +2,7 @@ require 'cloud/vsphere/logger'
 
 module VSphereCloud
   class FileProvider
-    extend Logger
+    include Logger
 
     def initialize(http_client:, vcenter_host:, retryer: nil)
       @vcenter_host = vcenter_host

--- a/src/vsphere_cpi/lib/cloud/vsphere/ip_conflict_detector.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/ip_conflict_detector.rb
@@ -1,8 +1,10 @@
+require 'cloud/vsphere/logger'
+
 module VSphereCloud
   class IPConflictDetector
+    extend Logger
 
-    def initialize(logger, client)
-      @logger = logger
+    def initialize(client)
       @client = client
     end
 
@@ -14,7 +16,7 @@ module VSphereCloud
       end
 
       if ip_conflicts.empty?
-        @logger.info("No IP conflicts detected")
+        logger.info("No IP conflicts detected")
       else
         raise "Detected IP conflicts with other VMs on the same networks: #{conflict_messages.join(", ")}"
       end
@@ -26,16 +28,16 @@ module VSphereCloud
       conflicts = []
       networks.each do |name, ips|
         ips.each do |ip|
-          @logger.info("Checking if ip '#{ip}' is in use")
+          logger.info("Checking if ip '#{ip}' is in use")
           vm = @client.find_vm_by_ip(ip)
           if vm.nil?
             next
           end
-          @logger.info("Found VM '#{vm.name}' with IP '#{ip}'. Checking if VM belongs to network '#{name}'...")
+          logger.info("Found VM '#{vm.name}' with IP '#{ip}'. Checking if VM belongs to network '#{name}'...")
 
           vm.guest.net.each do |nic|
             if nic.ip_address.include?(ip) && nic.network == name
-              @logger.info("found conflicting vm: #{vm.name}, on network: #{name} with ip: #{ip}")
+              logger.info("found conflicting vm: #{vm.name}, on network: #{name} with ip: #{ip}")
               conflicts << {vm_name: vm.name, network_name: name, ip: ip}
             end
           end

--- a/src/vsphere_cpi/lib/cloud/vsphere/ip_conflict_detector.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/ip_conflict_detector.rb
@@ -2,7 +2,7 @@ require 'cloud/vsphere/logger'
 
 module VSphereCloud
   class IPConflictDetector
-    extend Logger
+    include Logger
 
     def initialize(client)
       @client = client

--- a/src/vsphere_cpi/lib/cloud/vsphere/lease_obtainer.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/lease_obtainer.rb
@@ -1,17 +1,19 @@
+require 'cloud/vsphere/logger'
+
 module VSphereCloud
   class LeaseObtainer
     include VimSdk
+    extend Logger
 
-    def initialize(cloud_searcher, logger)
+    def initialize(cloud_searcher)
       @cloud_searcher = cloud_searcher
-      @logger = logger
     end
 
     def obtain(resource_pool, import_spec, template_folder)
-      @logger.info('Importing VApp')
+      logger.info('Importing VApp')
       nfc_lease = resource_pool.mob.import_vapp(import_spec, template_folder.mob, nil)
 
-      @logger.info('Waiting for NFC lease to become ready')
+      logger.info('Waiting for NFC lease to become ready')
       state = wait_for_nfc_lease(nfc_lease)
 
       if state == Vim::HttpNfcLease::State::ERROR

--- a/src/vsphere_cpi/lib/cloud/vsphere/lease_obtainer.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/lease_obtainer.rb
@@ -3,7 +3,7 @@ require 'cloud/vsphere/logger'
 module VSphereCloud
   class LeaseObtainer
     include VimSdk
-    extend Logger
+    include Logger
 
     def initialize(cloud_searcher)
       @cloud_searcher = cloud_searcher

--- a/src/vsphere_cpi/lib/cloud/vsphere/logger.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/logger.rb
@@ -2,8 +2,8 @@ require 'logger'
 
 module VSphereCloud
   module Logger
-    def self.extended(base)
-      base.__send__(:include, self)
+    def self.included(base)
+      base.extend(self)
     end
 
     def self.logger

--- a/src/vsphere_cpi/lib/cloud/vsphere/logger.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/logger.rb
@@ -1,0 +1,21 @@
+require 'logger'
+
+module VSphereCloud
+  module Logger
+    def self.extended(base)
+      base.__send__(:include, self)
+    end
+
+    def self.logger
+      @logger ||= ::Logger.new($stderr)
+    end
+
+    def self.logger=(logger)
+      @logger = logger
+    end
+
+    def logger
+      VSphereCloud::Logger.logger
+    end
+  end
+end

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsx.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsx.rb
@@ -3,7 +3,7 @@ require 'cloud/vsphere/logger'
 
 module VSphereCloud
   class NSX
-    extend Logger
+    include Logger
 
     # use a large number of retries as we investigate NSX error messages around finding VM ID
     # <error>

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_provider.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_provider.rb
@@ -86,7 +86,7 @@ module VSphereCloud
   end
 
   class NSXTProvider
-    extend Logger
+    include Logger
 
     def initialize(config)
       configuration = NSXT::Configuration.new

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster.rb
@@ -6,7 +6,7 @@ module VSphereCloud
     class Cluster
       include VimSdk
       include ObjectStringifier
-      extend Logger
+      include Logger
       stringify_with :name
 
       PROPERTIES = %w(name datastore resourcePool host)

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster.rb
@@ -1,3 +1,4 @@
+require 'cloud/vsphere/logger'
 require 'cloud/vsphere/resources/resource_pool'
 
 module VSphereCloud
@@ -5,6 +6,7 @@ module VSphereCloud
     class Cluster
       include VimSdk
       include ObjectStringifier
+      extend Logger
       stringify_with :name
 
       PROPERTIES = %w(name datastore resourcePool host)
@@ -28,14 +30,13 @@ module VSphereCloud
       # @param [ClusterConfig] config cluster configuration as specified by the
       #   operator.
       # @param [Hash] properties prefetched vSphere properties for the cluster.
-      def initialize(cluster_config, properties, logger, client)
-        @logger = logger
+      def initialize(cluster_config, properties, client)
         @client = client
         @properties = properties
 
         @config = cluster_config
         @mob = properties[:obj]
-        @resource_pool = ResourcePool.new(@client, @logger, cluster_config, properties['resourcePool'])
+        @resource_pool = ResourcePool.new(@client, cluster_config, properties['resourcePool'])
       end
 
       # @return [Integer] amount of free memory in the cluster
@@ -73,7 +74,7 @@ module VSphereCloud
 
       private
 
-      attr_reader :config, :client, :properties, :logger
+      attr_reader :config, :client, :properties
 
       def select_datastores(pattern)
         accessible_datastores.select { |name, datastore| name =~ pattern }

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster_provider.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster_provider.rb
@@ -6,7 +6,6 @@ module VSphereCloud
       def initialize(options)
         @datacenter_name = options.fetch(:datacenter_name)
         @client = options.fetch(:client)
-        @logger = options.fetch(:logger)
       end
 
       def find(name, config)
@@ -22,7 +21,6 @@ module VSphereCloud
         Cluster.new(
           config,
           cluster_properties,
-          @logger,
           @client
         )
       end

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/datacenter.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/datacenter.rb
@@ -6,7 +6,7 @@ module VSphereCloud
     class Datacenter
       include VimSdk
       include ObjectStringifier
-      extend Logger
+      include Logger
       stringify_with :name
 
       attr_accessor :config

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/folder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/folder.rb
@@ -3,7 +3,7 @@ require 'cloud/vsphere/logger'
 module VSphereCloud
   module Resources
     class Folder
-      extend Logger
+      include Logger
 
       attr_reader :mob, :path, :path_components
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/folder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/folder.rb
@@ -1,11 +1,14 @@
+require 'cloud/vsphere/logger'
+
 module VSphereCloud
   module Resources
     class Folder
+      extend Logger
+
       attr_reader :mob, :path, :path_components
 
-      def initialize(path, logger, client, datacenter_name)
+      def initialize(path, client, datacenter_name)
         @path = path
-        @logger = logger
         @client = client
         @datacenter_name = datacenter_name
         @path_components = path.split('/')
@@ -28,12 +31,12 @@ module VSphereCloud
           parent_folder = find_or_create_folder(path_components[0..-2])
 
           begin
-            @logger.debug("Creating folder #{last_component}")
+            logger.debug("Creating folder #{last_component}")
             folder = parent_folder.create_folder(last_component)
           rescue VimSdk::SoapError => e
             raise e unless VimSdk::Vim::Fault::DuplicateName === e.fault
 
-            @logger.debug("Folder already exists #{last_component}")
+            logger.debug("Folder already exists #{last_component}")
             folder = find_folder(path_components)
           end
         end

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/resource_pool.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/resource_pool.rb
@@ -1,17 +1,19 @@
+require 'cloud/vsphere/logger'
+
 module VSphereCloud
   module Resources
     class ResourcePool
       include VimSdk
+      extend Logger
 
       # Creates a new ResourcePool resource.
       #
       # @param [Cluster] cluster parent cluster.
       # @param [Vim::ResourcePool] root_resource_pool cluster's root resource
       #   pool.
-      def initialize(client, logger, cluster_config, root_resource_pool)
+      def initialize(client, cluster_config, root_resource_pool)
         @cluster_config = cluster_config
         @root_resource_pool = root_resource_pool
-        @logger = logger
         @client = client
       end
 
@@ -26,7 +28,6 @@ module VSphereCloud
           @mob = @root_resource_pool
         else
           client = @client
-          logger = @logger
           @mob = client.cloud_searcher.get_managed_object(
             Vim::ResourcePool,
             :root => @root_resource_pool,

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/resource_pool.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/resource_pool.rb
@@ -4,7 +4,7 @@ module VSphereCloud
   module Resources
     class ResourcePool
       include VimSdk
-      extend Logger
+      include Logger
 
       # Creates a new ResourcePool resource.
       #

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/task.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/task.rb
@@ -1,11 +1,10 @@
 module VSphereCloud
   module Resources
     class Task
-      def initialize(cloud_searcher, task_mob, retry_judge, logger)
+      def initialize(cloud_searcher, task_mob, retry_judge)
         @cloud_searcher = cloud_searcher
         @task_mob = task_mob
         @retry_judge = retry_judge
-        @logger = logger
       end
 
       def name

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -5,7 +5,7 @@ module VSphereCloud
     class VM
       include VimSdk
       include ObjectStringifier
-      extend Logger
+      include Logger
 
       stringify_with :cid
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -1,17 +1,20 @@
+require 'cloud/vsphere/logger'
+
 module VSphereCloud
   module Resources
     class VM
       include VimSdk
       include ObjectStringifier
+      extend Logger
+
       stringify_with :cid
 
       attr_reader :mob, :cid
 
-      def initialize(cid, mob, client, logger)
+      def initialize(cid, mob, client)
         @client = client
         @mob = mob
         @cid = cid
-        @logger = logger
       end
 
       def inspect
@@ -119,17 +122,17 @@ module VSphereCloud
       def shutdown
         check_for_nonpersistent_disk_modes
 
-        @logger.debug('Waiting for the VM to shutdown')
+        logger.debug('Waiting for the VM to shutdown')
         begin
           begin
             @mob.shutdown_guest
           rescue => e
-            @logger.debug("Ignoring possible race condition when a VM has powered off by the time we ask it to shutdown: #{e.inspect}")
+            logger.debug("Ignoring possible race condition when a VM has powered off by the time we ask it to shutdown: #{e.inspect}")
           end
 
           wait_until_off(60)
         rescue VSphereCloud::Cloud::TimeoutException
-          @logger.debug('The guest did not shutdown in time, requesting it to power off')
+          logger.debug('The guest did not shutdown in time, requesting it to power off')
           @client.power_off_vm(@mob)
         end
       end
@@ -140,7 +143,7 @@ module VSphereCloud
         question = properties['runtime.question']
         if question
           choices = question.choice
-          @logger.info("VM is blocked on a question: #{question.text}, " +
+          logger.info("VM is blocked on a question: #{question.text}, " +
               "providing default answer: #{choices.choice_info[choices.default_index].label}")
           @client.answer_vm(@mob, question.id, choices.choice_info[choices.default_index].key)
         end
@@ -151,7 +154,7 @@ module VSphereCloud
         if power_state != Vim::VirtualMachine::PowerState::POWERED_OFF
           @client.power_off_vm(@mob)
         else
-          @logger.info("VM '#{@cid}' is already powered off, skipping power off task.")
+          logger.info("VM '#{@cid}' is already powered off, skipping power off task.")
         end
       end
 
@@ -215,8 +218,8 @@ module VSphereCloud
         # get full path without a datastore
         file_path = disk.backing.file_name[/([^\]]*)\.vmdk/, 1].strip
         original_file_path = found_property.value[/([^\]]*)\.vmdk/, 1].strip
-        @logger.debug("Current file path is #{file_path}")
-        @logger.debug("Original file path is #{original_file_path}")
+        logger.debug("Current file path is #{file_path}")
+        logger.debug("Original file path is #{original_file_path}")
 
         file_path != original_file_path
       end
@@ -224,7 +227,7 @@ module VSphereCloud
       def get_old_disk_filepath(disk_key)
         property = get_vapp_property_by_key(disk_key)
         if property.nil? || !verify_persistent_disk_property?(property)
-          @logger.debug("Can't find persistent disk property for disk #{disk_key}")
+          logger.debug("Can't find persistent disk property for disk #{disk_key}")
           return nil
         end
 
@@ -246,14 +249,14 @@ module VSphereCloud
         vm_config.device_change << disk_config_spec
         fix_device_unit_numbers(vm_config.device_change)
 
-        @logger.info('Attaching disk')
+        logger.info('Attaching disk')
         @client.reconfig_vm(@mob, vm_config)
-        @logger.info('Finished attaching disk')
+        logger.info('Finished attaching disk')
 
         reload
-        @logger.debug("Adding persistent disk property to vm '#{@cid}'")
+        logger.debug("Adding persistent disk property to vm '#{@cid}'")
         @client.add_persistent_disk_property_to_vm(self, disk)
-        @logger.debug('Finished adding persistent disk property to vm')
+        logger.debug('Finished adding persistent disk property to vm')
         return disk_config_spec
       end
 
@@ -262,39 +265,39 @@ module VSphereCloud
         check_for_nonpersistent_disk_modes
 
         disks_to_move = []
-        @logger.info("Found #{virtual_disks.size} persistent disk(s)")
+        logger.info("Found #{virtual_disks.size} persistent disk(s)")
         config = Vim::Vm::ConfigSpec.new
         config.device_change = []
 
         virtual_disks.each do |virtual_disk|
-          @logger.info("Detaching: #{virtual_disk.backing.file_name}")
+          logger.info("Detaching: #{virtual_disk.backing.file_name}")
           config.device_change << Resources::VM.create_delete_device_spec(virtual_disk)
 
           disk_property = get_vapp_property_by_key(virtual_disk.key)
           unless disk_property.nil?
             if has_persistent_disk_property_mismatch?(virtual_disk) && !@client.disk_path_exists?(@mob, disk_property.value)
-              @logger.info('Persistent disk was moved: moving disk to expected location')
+              logger.info('Persistent disk was moved: moving disk to expected location')
               disks_to_move << virtual_disk
             end
           end
         end
 
         @client.reconfig_vm(@mob, config)
-        @logger.info("Detached #{virtual_disks.size} persistent disk(s)")
+        logger.info("Detached #{virtual_disks.size} persistent disk(s)")
 
         move_disks_to_old_path(disks_to_move)
 
-        @logger.info('Finished detaching disk(s)')
+        logger.info('Finished detaching disk(s)')
 
         virtual_disks.each do |disk|
-          @logger.debug("Deleting persistent disk property #{disk.key} from vm '#{@cid}'")
+          logger.debug("Deleting persistent disk property #{disk.key} from vm '#{@cid}'")
           @client.delete_persistent_disk_property_from_vm(self, disk.key)
         end
-        @logger.debug('Finished deleting persistent disk properties from vm')
+        logger.debug('Finished deleting persistent disk properties from vm')
       end
 
       def move_disks_to_old_path(disks_to_move)
-        @logger.info("Renaming #{disks_to_move.size} persistent disk(s)")
+        logger.info("Renaming #{disks_to_move.size} persistent disk(s)")
         disks_to_move.each do |disk|
           current_datastore = disk.backing.file_name.match(/^\[([^\]]+)\]/)[1]
           original_disk_path = get_old_disk_filepath(disk.key)

--- a/src/vsphere_cpi/lib/cloud/vsphere/sdk_helpers/retryable_stub_adapter.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/sdk_helpers/retryable_stub_adapter.rb
@@ -3,7 +3,7 @@ require 'cloud/vsphere/logger'
 module VSphereCloud
   module SdkHelpers
     class RetryableStubAdapter
-      extend Logger
+      include Logger
 
       PC = VimSdk::Vmodl::Query::PropertyCollector
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/soap_stub.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/soap_stub.rb
@@ -1,16 +1,18 @@
 require 'httpclient'
+require 'cloud/vsphere/logger'
 
 module VSphereCloud
   class SoapStub
-    def initialize(vcenter_api_uri, http_client, logger)
+    extend Logger
+
+    def initialize(vcenter_api_uri, http_client)
       @vcenter_api_uri = vcenter_api_uri
       @http_client = http_client
-      @logger = logger
     end
 
     def create
       base_stub = VimSdk::Soap::StubAdapter.new(@vcenter_api_uri, 'vim.version.version9', @http_client)
-      VSphereCloud::SdkHelpers::RetryableStubAdapter.new(base_stub, @logger)
+      VSphereCloud::SdkHelpers::RetryableStubAdapter.new(base_stub)
     end
   end
 end

--- a/src/vsphere_cpi/lib/cloud/vsphere/soap_stub.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/soap_stub.rb
@@ -3,7 +3,7 @@ require 'cloud/vsphere/logger'
 
 module VSphereCloud
   class SoapStub
-    extend Logger
+    include Logger
 
     def initialize(vcenter_api_uri, http_client)
       @vcenter_api_uri = vcenter_api_uri

--- a/src/vsphere_cpi/lib/cloud/vsphere/stemcell.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/stemcell.rb
@@ -1,11 +1,15 @@
 require 'securerandom'
 
+require 'cloud/vsphere/logger'
+
 module VSphereCloud
   class Stemcell
+    extend Logger
+
     attr_reader :id
 
-    def initialize(id, logger)
-      @id, @logger = id, logger
+    def initialize(id)
+      @id = id
     end
 
     def ==(other)
@@ -47,13 +51,13 @@ module VSphereCloud
       datastore_name = to_datastore_mob.info.name
 
       # Check if original stemcell lives on same datastore.
-      @logger.info("Searching for stemcell #{id} on datastore #{datastore_name}")
+      logger.info("Searching for stemcell #{id} on datastore #{datastore_name}")
       replica_vm = find_replica_in(datacenter.mob,  client, datastore_name)
       return replica_vm if replica_vm
 
       replica_name = "#{id} %2f #{to_datastore_mob.__mo_id__}"
 
-      @logger.info("No stemcell #{id} on datastore #{datastore_name}, replicating as #{replica_name}")
+      logger.info("No stemcell #{id} on datastore #{datastore_name}, replicating as #{replica_name}")
 
       begin
         clone_spec = VimSdk::Vim::Vm::CloneSpec.new
@@ -67,7 +71,7 @@ module VSphereCloud
           vm.clone(datacenter.template_folder.mob, replica_name, clone_spec)
         end
       rescue VSphereCloud::VCenterClient::DuplicateName
-        @logger.info("Stemcell is already being replicated, waiting for #{replica_name} to be ready")
+        logger.info("Stemcell is already being replicated, waiting for #{replica_name} to be ready")
         path_array = [datacenter.name, 'vm', datacenter.template_folder.path_components, replica_name]
         replica_vm = client.find_by_inventory_path(path_array.flatten)
         # cloud_searcher#get_properties will ensure the existence of a snapshot
@@ -75,18 +79,18 @@ module VSphereCloud
         # returning with the replicated stemcell vm. If a snapshot is not found
         # then an exception is thrown.
         client.cloud_searcher.get_properties(replica_vm, VimSdk::Vim::VirtualMachine, ['snapshot'], ensure_all: true)
-        @logger.info("Stemcell #{replica_name} has been replicated.")
+        logger.info("Stemcell #{replica_name} has been replicated.")
       else
-        @logger.info("Replicated #{id} to #{replica_name}")
+        logger.info("Replicated #{id} to #{replica_name}")
       end
 
       disable_sdrs(srm, datastore_cluster.mob, replica_vm) if datastore_cluster
 
-      @logger.info("Creating initial snapshot for linked clones on #{replica_vm}")
+      logger.info("Creating initial snapshot for linked clones on #{replica_vm}")
       client.wait_for_task do
         replica_vm.create_snapshot('initial', nil, false, false)
       end
-      @logger.info("Created initial snapshot for linked clones on #{replica_vm}")
+      logger.info("Created initial snapshot for linked clones on #{replica_vm}")
       replica_vm
     end
 
@@ -122,14 +126,14 @@ module VSphereCloud
 
       storage_placement_result = srm.recommend_datastores(storage_placement_spec)
       if storage_placement_result.drs_fault
-        @logger.info("Error raised when fetching recommendation for replicating #{id} from Storage DRS: #{storage_placement_result.drs_fault.reason}")
+        logger.info("Error raised when fetching recommendation for replicating #{id} from Storage DRS: #{storage_placement_result.drs_fault.reason}")
         raise "Storage DRS failed to make a recommendation for #{id}, Reason: #{storage_placement_result.drs_fault.reason}"
       end
 
       # pick first recommendation as that's the best one
       recommendation = storage_placement_result.recommendations.first
       raise "Storage DRS failed to make a recommendation for stemcell #{id} replication" unless recommendation
-      @logger.info("Recommendation from Storage DRS for: #{replica_name}, Destination: #{recommendation.action.first.destination.name}")
+      logger.info("Recommendation from Storage DRS for: #{replica_name}, Destination: #{recommendation.action.first.destination.name}")
 
       #TODO: loop over all actions to pick one with reason as storagePlacement
       if recommendation.reason == 'storagePlacement' && recommendation.action.first.destination.class == VimSdk::Vim::Datastore
@@ -138,7 +142,7 @@ module VSphereCloud
         srm.cancel_recommendation(recommendation.key)
         recommended_datastore
       else
-        @logger.info("No recommendation from Storage DRS for replicating #{id}")
+        logger.info("No recommendation from Storage DRS for replicating #{id}")
         raise "No recommendation from Storage DRS for replicating #{id}"
       end
     end
@@ -154,7 +158,7 @@ module VSphereCloud
     end
 
     def disable_sdrs(srm, datastore_cluster_mob, vm)
-      @logger.info("Disabling Storage DRS on replicated stemcell")
+      logger.info("Disabling Storage DRS on replicated stemcell")
       vm_info = VimSdk::Vim::StorageDrs::VmConfigInfo.new(vm: vm, enabled: false)
       vm_config_spec = VimSdk::Vim::StorageDrs::VmConfigSpec.new(info: vm_info, operation: VimSdk::Vim::Option::ArrayUpdateSpec::Operation::EDIT)
       storage_drs_config_spec = VimSdk::Vim::StorageDrs::ConfigSpec.new(vm_config_spec: [vm_config_spec])

--- a/src/vsphere_cpi/lib/cloud/vsphere/stemcell.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/stemcell.rb
@@ -4,7 +4,7 @@ require 'cloud/vsphere/logger'
 
 module VSphereCloud
   class Stemcell
-    extend Logger
+    include Logger
 
     attr_reader :id
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/storage_picker.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/storage_picker.rb
@@ -2,7 +2,7 @@ require 'cloud/vsphere/logger'
 
 module VSphereCloud
   module StoragePicker
-    extend Logger
+    include Logger
 
     module_function
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/storage_picker.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/storage_picker.rb
@@ -1,5 +1,9 @@
+require 'cloud/vsphere/logger'
+
 module VSphereCloud
   module StoragePicker
+    extend Logger
+
     module_function
 
     def choose_best_from(storage_objects)
@@ -7,7 +11,7 @@ module VSphereCloud
     end
 
     # @param [DiskPool] disk_pool
-    def choose_persistent_pattern(disk_pool, logger)
+    def choose_persistent_pattern(disk_pool)
       datastore_names = disk_pool.datastore_names
       unless disk_pool.datastore_clusters.empty?
         sdrs_enabled_datastore_clusters = disk_pool.datastore_clusters.select(&:drs_enabled?)
@@ -44,7 +48,7 @@ module VSphereCloud
     # @param [String] target_datastore_name
     # @param [Hash] accessible_datastores
     # @param [VmType] vm_type
-    def choose_ephemeral_storage(target_datastore_name, accessible_datastores, vm_type, logger)
+    def choose_ephemeral_storage(target_datastore_name, accessible_datastores, vm_type)
       #pick datastore set by cluster_picker based on ephemeral_pattern
       storage_options = [accessible_datastores[target_datastore_name]].compact
       logger.debug("Initial Storage Options for creating ephemeral disk from pattern: #{storage_options.map(&:name)}")
@@ -62,7 +66,7 @@ module VSphereCloud
     # if no datastores/datastore_clusters are specified, use global ephemeral pattern
 
     # @param [VmType] vm_type
-    def choose_ephemeral_pattern(vm_type, logger)
+    def choose_ephemeral_pattern(vm_type)
       datastore_names = vm_type.datastore_names
       unless vm_type.datastore_clusters.empty?
         sdrs_enabled_datastore_clusters = vm_type.datastore_clusters.select(&:drs_enabled?)

--- a/src/vsphere_cpi/lib/cloud/vsphere/task_runner.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/task_runner.rb
@@ -2,7 +2,7 @@ require 'cloud/vsphere/logger'
 
 module VSphereCloud
   class TaskRunner
-    extend Logger
+    include Logger
 
     def initialize(cloud_searcher:, retry_judge: nil, retryer: nil)
       @cloud_searcher = cloud_searcher

--- a/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
@@ -3,7 +3,7 @@ require 'cloud/vsphere/logger'
 module VSphereCloud
   class VCenterClient
     include VimSdk
-    extend Logger
+    include Logger
 
     class TaskException < StandardError; end
     class FileNotFoundException < TaskException; end

--- a/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
@@ -1,6 +1,9 @@
+require 'cloud/vsphere/logger'
+
 module VSphereCloud
   class VCenterClient
     include VimSdk
+    extend Logger
 
     class TaskException < StandardError; end
     class FileNotFoundException < TaskException; end
@@ -11,8 +14,8 @@ module VSphereCloud
 
     attr_reader :cloud_searcher, :service_content, :service_instance, :soap_stub
 
-    def initialize(vcenter_api_uri:, http_client:, logger:)
-      @soap_stub = SoapStub.new(vcenter_api_uri, http_client, logger).create
+    def initialize(vcenter_api_uri:, http_client:)
+      @soap_stub = SoapStub.new(vcenter_api_uri, http_client).create
 
       @service_instance = Vim::ServiceInstance.new('ServiceInstance', @soap_stub)
 
@@ -24,14 +27,10 @@ module VSphereCloud
 
       @metrics_cache  = {}
       @lock = Mutex.new
-      @logger = logger
 
-      @cloud_searcher = CloudSearcher.new(service_content, @logger)
+      @cloud_searcher = CloudSearcher.new(service_content)
 
-      @task_runner = TaskRunner.new({
-        cloud_searcher: @cloud_searcher,
-        logger: @logger,
-      })
+      @task_runner = TaskRunner.new(cloud_searcher: @cloud_searcher)
     end
 
     def login(username, password, locale)
@@ -44,7 +43,7 @@ module VSphereCloud
       @session = nil
       @service_content.session_manager.logout
     rescue VimSdk::SoapError => e
-      @logger.info "Failed to logout: #{e.message}"
+      logger.info "Failed to logout: #{e.message}"
     end
 
     def wait_for_task(&task_block)
@@ -77,7 +76,7 @@ module VSphereCloud
     end
 
     def upgrade_vm_virtual_hardware(vm)
-      @logger.info("Upgrading virtual hardware on VM")
+      logger.info("Upgrading virtual hardware on VM")
       wait_for_task do
         vm.upgrade_virtual_hardware
       end
@@ -143,7 +142,7 @@ module VSphereCloud
 
     def move_disk(source_datacenter_mob, source_path, dest_datacenter_mob, dest_path)
       create_parent_folder(dest_datacenter_mob, dest_path)
-      @logger.info("Moving disk: #{source_path} to #{dest_path}")
+      logger.info("Moving disk: #{source_path} to #{dest_path}")
       wait_for_task do
         service_content.virtual_disk_manager.move_virtual_disk(
           source_path,
@@ -154,7 +153,7 @@ module VSphereCloud
           nil
         )
       end
-      @logger.info('Moved disk')
+      logger.info('Moved disk')
     end
 
     def create_datastore_folder(folder_path, datacenter)
@@ -323,7 +322,7 @@ module VSphereCloud
       search_spec.query = [query]
 
       datastore_path = "[#{datastore.name}] #{disk_folder}"
-      @logger.debug("Trying to find disk in : #{datastore_path}")
+      logger.debug("Trying to find disk in : #{datastore_path}")
       result = wait_for_task do
         datastore.mob.browser.search(datastore_path, search_spec)
       end
@@ -345,7 +344,7 @@ module VSphereCloud
       search_spec.match_pattern = [match[3]]
 
       datastore_path = "[#{match[1]}] #{match[2]}"
-      @logger.debug("Trying to find disk in : #{datastore_path}")
+      logger.debug("Trying to find disk in : #{datastore_path}")
       result = wait_for_task do
         vm_mob.environment_browser.datastore_browser.search(datastore_path, search_spec)
       end
@@ -362,7 +361,7 @@ module VSphereCloud
       disk_device_key = vm_disk.key
 
       if vm.get_vapp_property_by_key(disk_device_key) != nil
-        @logger.debug("Disk property already exists '#{disk.cid}' on vm '#{vm.cid}'")
+        logger.debug("Disk property already exists '#{disk.cid}' on vm '#{vm.cid}'")
         return
       end
 
@@ -391,7 +390,7 @@ module VSphereCloud
 
     def delete_persistent_disk_property_from_vm(vm, disk_device_key)
       if vm.get_vapp_property_by_key(disk_device_key).nil?
-        @logger.debug("Disk property[#{disk_device_key}] does not exist on vm '#{vm.cid}'")
+        logger.debug("Disk property[#{disk_device_key}] does not exist on vm '#{vm.cid}'")
         return
       end
 
@@ -418,9 +417,9 @@ module VSphereCloud
         field = @fields_manager.add_field_definition(name, mob.class, nil, nil)
       rescue SoapError => e
         if e.fault.kind_of?(Vim::Fault::NoPermission)
-          @logger.warn("Can't create custom field definition due to lack of permission: #{e.message}")
+          logger.warn("Can't create custom field definition due to lack of permission: #{e.message}")
         elsif e.fault.kind_of?(Vim::Fault::DuplicateName)
-          @logger.warn("Custom field definition already exists: #{e.message}")
+          logger.warn("Custom field definition already exists: #{e.message}")
           custom_fields = @fields_manager.field
           field = custom_fields.find do |field|
             field.name == name && field.managed_object_type == mob.class
@@ -435,7 +434,7 @@ module VSphereCloud
         @fields_manager.set_field(mob, field.key, value)
         rescue SoapError => e
           if e.fault.kind_of?(Vim::Fault::NoPermission)
-            @logger.warn("Can't set custom fields due to lack of permission: #{e.message}")
+            logger.warn("Can't set custom fields due to lack of permission: #{e.message}")
           end
         end
       end

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -2,7 +2,7 @@ require 'cloud/vsphere/logger'
 
 module VSphereCloud
   class VmCreator
-    extend Logger
+    include Logger
 
     def initialize(client:, cloud_searcher:, cpi:, datacenter:, agent_env:, ip_conflict_detector:, default_disk_type:, enable_auto_anti_affinity_drs_rules:, stemcell:, upgrade_hw_version:)
       @client = client

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_provider.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_provider.rb
@@ -1,16 +1,15 @@
 module VSphereCloud
   class VMProvider
-    def initialize(datacenter, client, logger)
+    def initialize(datacenter, client)
       @datacenter = datacenter
       @client = client
-      @logger = logger
     end
 
     def find(vm_cid)
       vm_mob = @client.find_vm_by_name(@datacenter.mob, vm_cid)
       raise Bosh::Clouds::VMNotFound, "VM '#{vm_cid}' not found in datacenter '#{@datacenter.name}'" if vm_mob.nil?
 
-      Resources::VM.new(vm_cid, vm_mob, @client, @logger)
+      Resources::VM.new(vm_cid, vm_mob, @client)
     end
   end
 end

--- a/src/vsphere_cpi/spec/integration/client_spec.rb
+++ b/src/vsphere_cpi/spec/integration/client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module VSphereCloud
-  describe VCenterClient do
+  describe VCenterClient, fake_logger: true do
     before do
       @client, @datacenter, @datastore, @disk_folder = setup
     end
@@ -155,19 +155,16 @@ module VSphereCloud
       resource_pool_name = ENV.fetch('BOSH_VSPHERE_CPI_RESOURCE_POOL')
 
       cluster_configs = {cluster_name => ClusterConfig.new(cluster_name, {'resource_pool' => resource_pool_name})}
-      logger = Logger.new(StringIO.new(''))
 
       client = VSphereCloud::VCenterClient.new(
         vcenter_api_uri: URI.parse("https://#{host}/sdk/vimService"),
-        http_client: VSphereCloud::CpiHttpClient.new(logger),
-        logger: logger,
+        http_client: VSphereCloud::CpiHttpClient.new(logger)
       )
       client.login(user, password, 'en')
 
       cluster_provider = Resources::ClusterProvider.new(
         datacenter_name: datacenter_name,
-        client: client,
-        logger: logger
+        client: client
       )
       datacenter = Resources::Datacenter.new(
         client: client,
@@ -179,8 +176,7 @@ module VSphereCloud
         ephemeral_pattern: ephemeral_datastore_pattern,
         persistent_pattern: persistent_datastore_pattern,
         clusters: cluster_configs,
-        cluster_provider: cluster_provider,
-        logger: logger
+        cluster_provider: cluster_provider
       )
 
       regexp = Regexp.new(persistent_datastore_pattern)

--- a/src/vsphere_cpi/spec/integration/create_stemcell_spec.rb
+++ b/src/vsphere_cpi/spec/integration/create_stemcell_spec.rb
@@ -1,7 +1,7 @@
 require 'rspec'
 require 'integration/spec_helper'
 
-describe '#create_stemcell' do
+describe '#create_stemcell', fake_logger: true do
   subject(:cpi) do
     VSphereCloud::Cloud.new(cpi_options('default_disk_type' => 'thin'))
   end
@@ -10,8 +10,7 @@ describe '#create_stemcell' do
     stemcell = VSphereCloud::Resources::VM.new(
       @stemcell_id,
       @cpi.client.find_vm_by_name(@cpi.datacenter.mob, @stemcell_id),
-      @cpi.client,
-      Logger.new('/dev/null')
+      @cpi.client
     )
     expect(stemcell.system_disk.backing.thin_provisioned).to be(false)
   end
@@ -23,8 +22,7 @@ describe '#create_stemcell' do
         stemcell = VSphereCloud::Resources::VM.new(
           stemcell_id,
           cpi.client.find_vm_by_name(cpi.datacenter.mob, stemcell_id),
-          cpi.client,
-          Logger.new('/dev/null')
+          cpi.client
         )
         expect(stemcell.system_disk.backing.thin_provisioned).to be(true)
       ensure

--- a/src/vsphere_cpi/spec/integration/stemcell_replication_spec.rb
+++ b/src/vsphere_cpi/spec/integration/stemcell_replication_spec.rb
@@ -1,6 +1,6 @@
 require 'integration/spec_helper'
 
-context 'Replicating stemcells across datastores', external_cpi: false do
+context 'Replicating stemcells across datastores', external_cpi: false, fake_logger: true do
   before (:all) do
     @cluster_name = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_CLUSTER')
     @datastore_pattern = fetch_and_verify_datastore('BOSH_VSPHERE_CPI_DATASTORE_PATTERN', @cluster_name)
@@ -22,11 +22,10 @@ context 'Replicating stemcells across datastores', external_cpi: false do
     )
     VSphereCloud::Cloud.new(options)
   end
-  let(:logger) { double('logger', debug: nil, info: nil) }
   let(:destination_cluster) { @cpi.datacenter.clusters.find {|cluster| cluster.name == @cluster_name } }
 
   it 'raises an error when no stemcell exists for the given stemcell id' do
-    stemcell = VSphereCloud::Stemcell.new('abc123', logger)
+    stemcell = VSphereCloud::Stemcell.new('abc123')
     expect {
       stemcell.replicate(@cpi.datacenter,destination_cluster, @cpi.datacenter.accessible_datastores.values.first)
     }.to raise_error('Could not find VM for stemcell \'abc123\'')
@@ -39,7 +38,7 @@ context 'Replicating stemcells across datastores', external_cpi: false do
         stemcell_image = stemcell_image(@stemcell_path, temp_dir)
         @orig_stemcell_id = @cpi.create_stemcell(stemcell_image, nil)
         @original_stemcell_vm = @cpi.client.find_vm_by_name(@cpi.datacenter.mob, @orig_stemcell_id)
-        @stemcell = VSphereCloud::Stemcell.new(@orig_stemcell_id, logger)
+        @stemcell = VSphereCloud::Stemcell.new(@orig_stemcell_id)
       end
     end
 
@@ -172,7 +171,7 @@ context 'Replicating stemcells across datastores', external_cpi: false do
         stemcell_image = stemcell_image(@stemcell_path, temp_dir)
         @orig_stemcell_id = @cpi.create_stemcell(stemcell_image, nil)
         @original_stemcell_vm = @cpi.client.find_vm_by_name(@cpi.datacenter.mob, @orig_stemcell_id)
-        @stemcell = VSphereCloud::Stemcell.new(@orig_stemcell_id, logger)
+        @stemcell = VSphereCloud::Stemcell.new(@orig_stemcell_id)
       end
     end
 

--- a/src/vsphere_cpi/spec/integration/vsphere_cpi_spec.rb
+++ b/src/vsphere_cpi/spec/integration/vsphere_cpi_spec.rb
@@ -5,7 +5,7 @@ require 'yaml'
 require 'fileutils'
 
 module VSphereCloud
-  describe Cloud, external_cpi: true do
+  describe Cloud, external_cpi: true, fake_logger: true do
     before(:each) do
       @workspace_dir = Dir.mktmpdir('vsphere-cloud-spec')
       @config_path = File.join(@workspace_dir, 'vsphere_cpi_config')
@@ -46,11 +46,9 @@ module VSphereCloud
       ephemeral_datastore_pattern = ENV.fetch('BOSH_VSPHERE_CPI_DATASTORE_PATTERN')
       persistent_datastore_pattern = ENV.fetch('BOSH_VSPHERE_CPI_SECOND_DATASTORE')
 
-      logger = Logger.new(StringIO.new(""))
       client = VSphereCloud::VCenterClient.new(
           vcenter_api_uri: URI.parse("https://#{host}/sdk/vimService"),
-          http_client: VSphereCloud::CpiHttpClient.new(logger),
-          logger: logger,
+          http_client: VSphereCloud::CpiHttpClient.new(logger)
       )
       client.login(user, password, 'en')
 

--- a/src/vsphere_cpi/spec/spec_helper.rb
+++ b/src/vsphere_cpi/spec/spec_helper.rb
@@ -22,6 +22,12 @@ class VSphereSpecConfig
   attr_accessor :logger, :uuid
 end
 
+RSpec.shared_context 'with a fake logger' do
+  require 'cloud/vsphere/logger'
+  before { VSphereCloud::Logger.logger = logger }
+  let(:logger) { Logger.new(StringIO.new('')) }
+end
+
 RSpec.configure do |config|
   config.include Support
 
@@ -32,4 +38,6 @@ RSpec.configure do |config|
   config.before do
     expect(RUBY_VERSION).to eq(PROJECT_RUBY_VERSION)
   end
+
+  config.include_context 'with a fake logger', fake_logger: true
 end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_searcher_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_searcher_spec.rb
@@ -2,10 +2,9 @@ require 'spec_helper'
 # require 'cloud/vsphere/cloud_searcher'
 
 describe VSphereCloud::CloudSearcher do
-  subject(:cloud_searcher) { VSphereCloud::CloudSearcher.new(service_content, logger) }
+  subject(:cloud_searcher) { VSphereCloud::CloudSearcher.new(service_content) }
 
   let(:service_content) { double('service content', root_folder: double('fake-root-folder')) }
-  let(:logger) { instance_double('Logger') }
 
   let(:property_collector) { instance_double('VimSdk::Vmodl::Query::PropertyCollector') }
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/drs_rules/drs_lock_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/drs_rules/drs_lock_spec.rb
@@ -1,10 +1,9 @@
 require 'spec_helper'
 require 'timecop'
 
-describe VSphereCloud::DrsLock do
-  subject(:drs_lock) { described_class.new(vm_attribute_manager, logger) }
+describe VSphereCloud::DrsLock, fake_logger: true do
+  subject(:drs_lock) { described_class.new(vm_attribute_manager) }
   let(:vm_attribute_manager) { instance_double('VSphereCloud::VMAttributeManager') }
-  let(:logger) { instance_double('Logger', debug: nil) }
 
   context 'when drs lock exists' do
     context 'when lock is released within timeout' do

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/drs_rules/drs_rule_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/drs_rules/drs_rule_spec.rb
@@ -1,13 +1,12 @@
 require 'spec_helper'
 
-describe VSphereCloud::DrsRule do
+describe VSphereCloud::DrsRule, fake_logger: true do
   subject(:drs_rule) do
     described_class.new(
       'fake-rule-name',
       client,
       cloud_searcher,
       datacenter_cluster,
-      logger
     )
   end
   let(:client) { instance_double('VSphereCloud::VCenterClient') }
@@ -52,8 +51,6 @@ describe VSphereCloud::DrsRule do
 
   let(:drs_lock) { instance_double('VSphereCloud::DrsLock') }
   before { allow(VSphereCloud::DrsLock).to receive(:new).and_return(drs_lock) }
-
-  let(:logger) { instance_double('Logger', debug: nil) }
 
   def with_lock
     expect(drs_lock).to receive(:with_drs_lock).and_yield.ordered

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/drs_rules/vm_attribute_manager_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/drs_rules/vm_attribute_manager_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe VSphereCloud::VMAttributeManager do
-  subject(:vm_attribute_manager) { described_class.new(custom_fields_manager, logger) }
+describe VSphereCloud::VMAttributeManager, fake_logger: true do
+  subject(:vm_attribute_manager) { described_class.new(custom_fields_manager) }
   let(:custom_fields_manager) { instance_double('VimSdk::Vim::CustomFieldsManager') }
   before do
     allow(custom_fields_manager).to receive(:field).and_return(
@@ -13,8 +13,6 @@ describe VSphereCloud::VMAttributeManager do
   end
 
   let(:field_matching_field) { double(:field_matching_field, name: 'fake-matching-field', key: 42) }
-
-  let(:logger) { instance_double('Logger', debug: nil) }
 
   describe 'find_by_name' do
     it 'returns the field with the specified name' do

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/file_provider_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/file_provider_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
 module VSphereCloud
-  describe FileProvider do
-    subject(:file_provider) { described_class.new(http_client: http_client, vcenter_host: vcenter_host, logger: logger, retryer: retryer) }
+  describe FileProvider, fake_logger: true do
+    subject(:file_provider) { described_class.new(http_client: http_client, vcenter_host: vcenter_host, retryer: retryer) }
 
     let(:http_client) { double('fake-rest-client') }
     let(:vcenter_host) { 'fake-vcenter-host' }
-    let(:logger) { Logger.new(StringIO.new("")) }
     let(:retryer) { Retryer.new }
 
     let(:datacenter_name) { 'fake-datacenter-name 1' }

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/ip_conflict_detector_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/ip_conflict_detector_spec.rb
@@ -1,21 +1,20 @@
 require 'spec_helper'
 
 module VSphereCloud
-  describe IPConflictDetector do
+  describe IPConflictDetector, fake_logger: true do
     let(:networks) do
       {
         'network_1' => ['169.254.1.1'],
         'network_2' => ['169.254.2.1', '169.254.3.1']
       }
     end
-    let(:logger) { double('logger', debug: nil, info: nil) }
     let(:client) { instance_double(VSphereCloud::VCenterClient) }
 
     context 'when no existing VMs on a desired network report having the desired IP' do
       it 'does not detect a conflict with deployed VMs' do
         allow(client).to receive(:find_vm_by_ip).and_return(nil)
 
-        conflict_detector = IPConflictDetector.new(logger, client)
+        conflict_detector = IPConflictDetector.new(client)
         expect {
           conflict_detector.ensure_no_conflicts(networks)
         }.to_not raise_error
@@ -57,7 +56,7 @@ module VSphereCloud
           allow(client).to receive(:find_vm_by_ip).with('169.254.2.1').and_return(deployed_vm)
           allow(client).to receive(:find_vm_by_ip).with('169.254.3.1').and_return(deployed_vm)
 
-          conflict_detector = IPConflictDetector.new(logger, client)
+          conflict_detector = IPConflictDetector.new(client)
           expect {
             conflict_detector.ensure_no_conflicts(networks)
           }.to raise_error do |error|
@@ -92,7 +91,7 @@ module VSphereCloud
           allow(client).to receive(:find_vm_by_ip).with('169.254.1.1').and_return(deployed_vm)
           allow(client).to receive(:find_vm_by_ip).with('169.254.2.1').and_return(deployed_vm)
           allow(client).to receive(:find_vm_by_ip).with('169.254.3.1').and_return(deployed_vm)
-          conflict_detector = IPConflictDetector.new(logger, client)
+          conflict_detector = IPConflictDetector.new(client)
           expect {
             conflict_detector.ensure_no_conflicts(networks)
           }.to_not raise_error

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/lease_obtainer_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/lease_obtainer_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
 module VSphereCloud
-  describe LeaseObtainer do
+  describe LeaseObtainer, fake_logger: true do
     describe '#obtain' do
-      subject(:lease_obtainer) { described_class.new(cloud_searcher, logger) }
+      subject(:lease_obtainer) { described_class.new(cloud_searcher) }
       let(:cloud_searcher) { instance_double('VSphereCloud::CloudSearcher') }
-      let(:logger) { instance_double(Logger, info: nil) }
 
       let(:resource_pool) { instance_double('VSphereCloud::Resources::ResourcePool', mob: resource_pool_mob) }
       let(:resource_pool_mob) { instance_double('VimSdk::Vim::ResourcePool') }

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_spec.rb
@@ -2,10 +2,9 @@ require 'spec_helper'
 require 'oga'
 
 module VSphereCloud
-  describe NSX do
+  describe NSX, fake_logger: true do
 
     let(:http_client)           { instance_double(NsxHttpClient) }
-    let(:logger)                { Logger.new('/dev/null') }
     let(:vm_id)                 { 'my-vm-id' }
     let(:vm_name)               { 'my-vm-name' }
     let(:nsx_address)           { 'my-nsx-manager' }
@@ -35,7 +34,7 @@ module VSphereCloud
     }
 
     subject(:nsx) do
-      described_class.new(nsx_address, http_client, logger).tap do |nsx|
+      described_class.new(nsx_address, http_client).tap do |nsx|
         nsx.sleep_time = 0
       end
     end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/nsxt_provider_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/nsxt_provider_spec.rb
@@ -1,7 +1,7 @@
 require 'digest'
 require 'spec_helper'
 
-describe VSphereCloud::NSXTProvider do
+describe VSphereCloud::NSXTProvider, fake_logger: true do
   let(:client) { instance_double(NSXT::ApiClient) }
   let(:nsxt_config) { VSphereCloud::NSXTConfig.new('fake-host', 'fake-username', 'fake-password') }
   let(:opaque_nsxt) do
@@ -66,7 +66,6 @@ describe VSphereCloud::NSXTProvider do
     NSXT::NSGroupSimpleExpression.new(:op => 'EQUALS', :resource_type => 'NSXT::LogicalPort',
                                       :target_property => 'id', :value => logical_port_2.id)
   end
-  let(:logger) { Logger.new('/dev/null') }
 
   let(:grouping_obj_svc) do
     NSXT::GroupingObjectsApi.new(client)
@@ -85,7 +84,7 @@ describe VSphereCloud::NSXTProvider do
   end
 
   subject(:nsxt_provider) do
-    described_class.new(nsxt_config, logger).tap do |provider|
+    described_class.new(nsxt_config).tap do |provider|
       provider.instance_variable_set('@client', client)
     end
   end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/cluster_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/cluster_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
 module VSphereCloud::Resources
-  describe Cluster do
+  describe Cluster, fake_logger: true do
     subject(:cluster) do
       VSphereCloud::Resources::Cluster.new(
         cluster_config,
         properties,
-        logger,
         client
       )
     end
@@ -14,7 +13,6 @@ module VSphereCloud::Resources
     let(:datacenter) { instance_double('VSphereCloud::Resources::Datacenter') }
 
     let(:log_output) { StringIO.new("") }
-    let(:logger) { Logger.new(log_output) }
     let(:client) { instance_double('VSphereCloud::VCenterClient', cloud_searcher: cloud_searcher) }
     let(:cloud_searcher) { instance_double('VSphereCloud::CloudSearcher') }
 
@@ -73,7 +71,7 @@ module VSphereCloud::Resources
 
     before do
       allow(ResourcePool).to receive(:new).with(
-        client, logger, cluster_config, fake_resource_pool_mob
+        client, cluster_config, fake_resource_pool_mob
       ).and_return(fake_resource_pool)
 
       allow(cloud_searcher).to receive(:get_properties).with(
@@ -258,7 +256,7 @@ module VSphereCloud::Resources
     describe '#resource_pool' do
       it 'returns a resource pool object backed by the resource pool in the cloud properties' do
         expect(cluster.resource_pool).to eq(fake_resource_pool)
-        expect(ResourcePool).to have_received(:new).with(client, logger, cluster_config, fake_resource_pool_mob)
+        expect(ResourcePool).to have_received(:new).with(client, cluster_config, fake_resource_pool_mob)
       end
     end
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datacenter_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datacenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe VSphereCloud::Resources::Datacenter do
+describe VSphereCloud::Resources::Datacenter, fake_logger: true do
   subject(:datacenter) do
     described_class.new(
       client: client,
@@ -15,12 +15,9 @@ describe VSphereCloud::Resources::Datacenter do
       disk_path: 'fake-disk-path',
       ephemeral_pattern: ephemeral_pattern,
       persistent_pattern: persistent_pattern,
-      use_sub_folder: datacenter_use_sub_folder,
-      logger: logger,
+      use_sub_folder: datacenter_use_sub_folder
     )
   end
-  let(:log_output) { StringIO.new('') }
-  let(:logger) { Logger.new(log_output) }
   let(:client) { instance_double('VSphereCloud::VCenterClient') }
 
   let(:vm_folder) { instance_double('VSphereCloud::Resources::Folder') }
@@ -92,19 +89,19 @@ describe VSphereCloud::Resources::Datacenter do
     allow(client).to receive(:cloud_searcher).and_return(cloud_searcher)
 
     allow(VSphereCloud::Resources::Folder).to receive(:new).with(
-      'fake-vm-folder', logger, client, datacenter_name
+      'fake-vm-folder', client, datacenter_name
     ).and_return(vm_folder)
 
     allow(VSphereCloud::Resources::Folder).to receive(:new).with(
-      'fake-vm-folder/fake-uuid', logger, client, datacenter_name
+      'fake-vm-folder/fake-uuid', client, datacenter_name
     ).and_return(vm_subfolder)
 
     allow(VSphereCloud::Resources::Folder).to receive(:new).with(
-      'fake-template-folder', logger, client, datacenter_name
+      'fake-template-folder', client, datacenter_name
     ).and_return(template_folder)
 
     allow(VSphereCloud::Resources::Folder).to receive(:new).with(
-      'fake-template-folder/fake-uuid', logger, client, datacenter_name
+      'fake-template-folder/fake-uuid', client, datacenter_name
     ).and_return(template_subfolder)
 
     allow(cloud_searcher).to receive(:get_managed_objects).with(
@@ -422,7 +419,7 @@ describe VSphereCloud::Resources::Datacenter do
 
         before do
           expect(client).to receive(:find_vm_by_disk_cid).with(datacenter_mob, 'disk-cid').and_return(vm_mob)
-          expect(VSphereCloud::Resources::VM).to receive(:new).with('fake-vm-name', vm_mob, client, logger).and_return(vm)
+          expect(VSphereCloud::Resources::VM).to receive(:new).with('fake-vm-name', vm_mob, client).and_return(vm)
         end
 
         # unexpected event has destroyed the disk

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/folder_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/folder_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
-describe VSphereCloud::Resources::Folder do
-  subject(:folder) { VSphereCloud::Resources::Folder.new(folder_path, logger, client, datacenter_name) }
+describe VSphereCloud::Resources::Folder, fake_logger: true do
+  subject(:folder) { VSphereCloud::Resources::Folder.new(folder_path, client, datacenter_name) }
   let(:folder_path) { 'fake-parent-folder-name/fake-sub-folder-name' }
 
   let(:client) { instance_double('VSphereCloud::VCenterClient') }
-  let(:logger) { instance_double('Logger', debug: nil) }
   let(:datacenter_name) { 'fake-datacenter-name' }
   let(:parent_folder_mob) { double(:fake_parent_folder_mob) }
   let(:sub_folder_mob) { double(:fake_sub_folder_mob) }

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/resource_pool_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/resource_pool_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
-describe VSphereCloud::Resources::ResourcePool do
-  subject { VSphereCloud::Resources::ResourcePool.new(fake_client, fake_logger, cluster_config, root_resource_pool_mob) }
-  let(:fake_logger) { instance_double('Logger', debug: nil) }
+describe VSphereCloud::Resources::ResourcePool, fake_logger: true do
+  subject { VSphereCloud::Resources::ResourcePool.new(fake_client, cluster_config, root_resource_pool_mob) }
   let(:fake_client) { instance_double('VSphereCloud::VCenterClient', cloud_searcher: cloud_searcher) }
   let(:cloud_searcher) { instance_double('VSphereCloud::CloudSearcher') }
   let(:cluster_config) do

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/task_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/task_spec.rb
@@ -1,17 +1,15 @@
 require 'spec_helper'
 
-describe VSphereCloud::Resources::Task do
+describe VSphereCloud::Resources::Task, fake_logger: true do
   subject(:task) do
     VSphereCloud::Resources::Task.new(
       cloud_searcher,
       task_mob,
-      retry_judge,
-      logger,
+      retry_judge
     )
   end
   let(:cloud_searcher) { double(VSphereCloud::CloudSearcher) }
   let(:task_mob) { instance_double(VimSdk::Vim::Task) }
-  let(:logger) { instance_double('Logger', debug: nil) }
   let(:retry_judge) { VSphereCloud::SdkHelpers::RetryJudge.new }
 
   let(:task_info) do

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/vm_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/vm_spec.rb
@@ -1,13 +1,12 @@
 require 'spec_helper'
 require 'timecop'
 
-describe VSphereCloud::Resources::VM do
-  subject(:vm) { described_class.new('vm-cid', vm_mob, client, logger) }
+describe VSphereCloud::Resources::VM, fake_logger: true do
+  subject(:vm) { described_class.new('vm-cid', vm_mob, client) }
   let(:vm_mob) { instance_double('VimSdk::Vim::VirtualMachine', __mo_id__: 'fake-mob-id') }
   let(:datacenter) { instance_double('VimSdk::Vim::Datacenter')}
   let(:client) { instance_double('VSphereCloud::VCenterClient', cloud_searcher: cloud_searcher) }
   let(:cloud_searcher) { instance_double('VSphereCloud::CloudSearcher') }
-  let(:logger) { double(:logger, debug: nil, info: nil) }
 
   let(:powered_off_state) { VimSdk::Vim::VirtualMachine::PowerState::POWERED_OFF }
   let(:powered_on_state) { VimSdk::Vim::VirtualMachine::PowerState::POWERED_ON }

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/sdk_helpers/retryable_stub_adapter_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/sdk_helpers/retryable_stub_adapter_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 require 'ruby_vim_sdk'
 
-describe 'RetryableStubAdapter' do
+describe 'RetryableStubAdapter', fake_logger: true do
   subject(:retryable_stub_adapter) do
-    VSphereCloud::SdkHelpers::RetryableStubAdapter.new(stub_adapter, logger, retry_judge, retryer)
+    VSphereCloud::SdkHelpers::RetryableStubAdapter.new(stub_adapter, retry_judge, retryer)
   end
 
   let(:stub_adapter) { instance_double(VimSdk::Soap::StubAdapter) }
@@ -12,7 +12,6 @@ describe 'RetryableStubAdapter' do
   let(:method_info) { double('some-method-info', wsdl_name: 'PowerOnVM_Task') }
   let(:method_args) { nil }
   let(:retry_judge) { VSphereCloud::SdkHelpers::RetryJudge.new }
-  let(:logger) { Logger.new(StringIO.new("")) }
   let(:retryer) { VSphereCloud::Retryer.new }
 
   describe '#invoke_method' do
@@ -135,8 +134,7 @@ describe 'RetryableStubAdapter' do
           expect {
             retryable_stub_adapter.invoke_method(managed_object, method_info, method_args)
           }.to raise_error(Errno::ECONNRESET)
-          expect(retryable_stub_adapter.instance_variable_get(:@logger).
-            instance_variable_get(:@logdev).dev.string).to eql("")
+          expect(retryable_stub_adapter.logger.instance_variable_get(:@logdev).dev.string).to eql("")
         end
       end
     end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/soap_stub_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/soap_stub_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 require 'tempfile'
 
-describe VSphereCloud::SoapStub do
-  let(:soap_stub) { described_class.new('https://some-host/sdk/vimService', http_client, logger) }
+describe VSphereCloud::SoapStub, fake_logger: true do
+  let(:soap_stub) { described_class.new('https://some-host/sdk/vimService', http_client) }
   let(:http_client) { instance_double('HTTPClient') }
   let(:base_adapter) { instance_double(VimSdk::Soap::StubAdapter) }
   let(:retryable_adapter) { instance_double(VSphereCloud::SdkHelpers::RetryableStubAdapter) }
-  let(:logger) { Logger.new(StringIO.new("")) }
 
   describe '#create' do
     it 'returns the SDK Soap Adapter' do
@@ -20,7 +19,6 @@ describe VSphereCloud::SoapStub do
       expect(VSphereCloud::SdkHelpers::RetryableStubAdapter).to receive(:new)
        .with(
          base_adapter,
-         logger,
        )
        .and_return(retryable_adapter)
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/stemcell_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/stemcell_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 require 'cloud/vsphere/stemcell'
 
-describe VSphereCloud::Stemcell do
-  subject { described_class.new(stemcell_id, logger) }
+describe VSphereCloud::Stemcell, fake_logger: true do
+  subject { described_class.new(stemcell_id) }
   let(:stemcell_id) { 'fake_stemcell_id' }
 
-  let(:logger) { instance_double('Bosh::Cpi::Logger', info: nil, debug: nil) }
   let(:cloud_searcher) { instance_double('VSphereCloud::CloudSearcher') }
   let(:client) { instance_double('VSphereCloud::VCenterClient', cloud_searcher: cloud_searcher) }
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/storage_picker_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/storage_picker_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 module VSphereCloud
-  describe StoragePicker do
-    let(:fake_logger) { instance_double('Logger', info: nil, debug: nil) }
-
+  describe StoragePicker, fake_logger: true do
     let(:global_ephemeral_pattern) { 'global-ephemeral-ds' }
     let(:global_persistent_pattern) { 'global-persistent-ds' }
     let(:datacenter) { double('Datacenter', ephemeral_pattern: global_ephemeral_pattern, persistent_pattern: global_persistent_pattern) }
@@ -29,7 +27,7 @@ module VSphereCloud
     describe '.choose_persistent_pattern' do
       let(:disk_pool) { DiskPool.new(datacenter, []) }
 
-      subject {  described_class.choose_persistent_pattern(disk_pool, fake_logger) }
+      subject {  described_class.choose_persistent_pattern(disk_pool) }
 
       before do
         allow(disk_pool).to receive(:datastore_clusters).and_return(datastore_clusters)
@@ -75,7 +73,7 @@ module VSphereCloud
     describe '.choose_ephemeral_pattern' do
       let(:vm_type) { VmType.new(datacenter, {}) }
 
-      subject {  described_class.choose_ephemeral_pattern(vm_type, fake_logger) }
+      subject {  described_class.choose_ephemeral_pattern(vm_type) }
 
       before do
         allow(vm_type).to receive(:datastore_clusters).and_return(datastore_clusters)
@@ -135,13 +133,13 @@ module VSphereCloud
             it 'considers all sdrs enabled datastore cluster' do
               expected_storage_options = [datastore1, sdrs_enabled_datastore_cluster1, sdrs_enabled_datastore_cluster2]
               expect(described_class).to receive(:choose_best_from).with(expected_storage_options)
-              described_class.choose_ephemeral_storage(target_datastore_name, accessible_datastores, vm_type, fake_logger)
+              described_class.choose_ephemeral_storage(target_datastore_name, accessible_datastores, vm_type)
             end
 
             it 'should not include nil datastore for unmatched target_datastore_pattern from accessibe_datastores' do
               expected_storage_options = [sdrs_enabled_datastore_cluster1, sdrs_enabled_datastore_cluster2]
               expect(described_class).to receive(:choose_best_from).with(expected_storage_options)
-              described_class.choose_ephemeral_storage(target_datastore_name, {}, vm_type, fake_logger)
+              described_class.choose_ephemeral_storage(target_datastore_name, {}, vm_type)
             end
           end
         end
@@ -150,7 +148,7 @@ module VSphereCloud
           let(:datastore_clusters) { [sdrs_disabled_datastore_cluster] }
           it 'should not consider any datastore cluster' do
             expect(described_class).to receive(:choose_best_from).with([datastore1])
-            described_class.choose_ephemeral_storage(target_datastore_name, accessible_datastores, vm_type, fake_logger)
+            described_class.choose_ephemeral_storage(target_datastore_name, accessible_datastores, vm_type)
           end
         end
       end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_provider_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_provider_spec.rb
@@ -1,10 +1,9 @@
 require 'spec_helper'
 
-describe VSphereCloud::VMProvider do
-  subject(:vm_provider) { described_class.new(datacenter, client, logger) }
+describe VSphereCloud::VMProvider, fake_logger: true do
+  subject(:vm_provider) { described_class.new(datacenter, client) }
   let(:datacenter) { instance_double('VSphereCloud::Resources::Datacenter') }
   let(:client) { instance_double('VSphereCloud::VCenterClient') }
-  let(:logger) { instance_double('Logger') }
 
   describe 'find' do
     before do


### PR DESCRIPTION
Still a work in progress. After doing:

```ruby
require 'cloud/vsphere/logger'
```

It's possible to do:

```ruby
extend VSphereCloud::Logger
```

To gain `logger` as both an instance and a singleton method. Basically every file has been touched but the actual change is present in `src/vsphere_cpi/lib/cloud/vsphere/logger.rb`.