### PR TITLE
Fix datastore picker logic

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/datastore_picker.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/datastore_picker.rb
@@ -8,7 +8,7 @@ module VSphereCloud
     end
 
     def update(available_datastores={})
-      @available_datastores = available_datastores
+      @available_datastores = available_datastores || {}
     end
 
     # Placement Algorithm:
@@ -20,8 +20,9 @@ module VSphereCloud
     #
     def best_disk_placement(disks)
       datastores = {}
+      # Create a possible placement hash
       placement = { datastores: datastores, migration_size: 0, balance_score: 0 }
-
+      # Gather all available datastores in the possible placement hash
       @available_datastores.each do |name, props|
         datastores[name] = {
           free_space: props.free_space,
@@ -32,40 +33,46 @@ module VSphereCloud
 
       # Reject all the datastores that are in maintenance mode.
       # Possible states are
-      #   enteringMaintenance	Started entering maintenance mode, but not finished. This could happen when waiting for user input or for long-running vmotions to complete.
+      #   enteringMaintenance	Started entering maintenance mode, but not finished.
+      #       This could happen when waiting for user input or for long-running vmotions to complete.
       #   inMaintenance	Successfully entered maintenance mode.
       #   normal	Default state.
-      datastores.keep_if do |name, props|
+      datastores.keep_if do |_, props|
         props[:mob].summary.maintenance_mode == "normal"
       end
 
+      raise Bosh::Clouds::CloudError, "Datastores matching criteria are in maintenance mode or not accessible. No valid placement found" if placement[:datastores].empty?
+
+      # At this step we only have datastores that are not in maintenance mode
+      # and are accessible from at least 1 active host.
       disks.each do |disk|
         existing_ds_name = disk.existing_datastore_name
 
+        # Only persistent disks will have existing_ds_name
         if existing_ds_name =~ Regexp.new(disk.target_datastore_pattern) && datastores.keys.include?(existing_ds_name)
           datastores[existing_ds_name][:disks].push(disk)
           next
         end
 
-        migration_size_accounted_for = false
-
+        placement_found = false
         weighted_datastores = weighted_random_sort(datastores)
         weighted_datastores.each do |ds|
           additional_required_space = disk.size + @headroom
 
           ds_name = ds[0]
           ds_props = ds[1]
+
           next if additional_required_space > ds_props[:free_space]
           next unless ds_name =~ Regexp.new(disk.target_datastore_pattern)
 
           datastores[ds_name][:disks].push(disk)
           datastores[ds_name][:free_space] -= additional_required_space
-          if existing_ds_name && !migration_size_accounted_for
-            placement[:migration_size] += additional_required_space
-            migration_size_accounted_for = true
-          end
-        end
+          placement[:migration_size] += additional_required_space if existing_ds_name
 
+          placement_found = true
+          break
+        end
+        raise Bosh::Clouds::CloudError, pretty_print_placement_error([disk]) unless placement_found
       end
 
       placement = filter_all_placement_without_disks(placement)
@@ -85,27 +92,9 @@ module VSphereCloud
       placement
     end
 
-    def persistent_placements_with_active_hosts(placements)
-      @available_datastores.each do |dsname, ds|
-        placements[:datastores].delete(dsname) unless ds.accessible?
-      end
-      placements
-    end
-
     def pick_datastore_for_single_disk(disk)
       placement = best_disk_placement([disk])
-      # Filter out placements where the datastore has no active hosts
-      # (host under maintenance) or if there are any active host,
-      # they belong to a different cluster
-      # than specified in placement_options' respective key
-      placement = persistent_placements_with_active_hosts(placement)
-
-      if placement[:datastores].empty?
-        raise Bosh::Clouds::CloudError,
-              "No valid placement found due to no active host (non-maintenance) present for chosen datastore pattern\n\n"
-      end
-
-      # we should always find a matching datastore for the disk because best_disk_placement raises an error if no placement was found
+      # we should always find a matching datastore for the disk because best_disk_placement raises an error if no placement was found.
       placement[:datastores].keys.first
     end
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/datastore_picker.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/datastore_picker.rb
@@ -8,7 +8,7 @@ module VSphereCloud
     end
 
     def update(available_datastores={})
-      @available_datastores = available_datastores || {}
+      @available_datastores = available_datastores
     end
 
     # Placement Algorithm:
@@ -40,7 +40,6 @@ module VSphereCloud
       datastores.keep_if do |_, props|
         props[:mob].summary.maintenance_mode == "normal"
       end
-
       raise Bosh::Clouds::CloudError, "Datastores matching criteria are in maintenance mode or not accessible. No valid placement found" if placement[:datastores].empty?
 
       # At this step we only have datastores that are not in maintenance mode

--- a/src/vsphere_cpi/spec/integration/datastore_maintenance_mode_spec.rb
+++ b/src/vsphere_cpi/spec/integration/datastore_maintenance_mode_spec.rb
@@ -48,7 +48,7 @@ context 'when regex matching datastores in a datastore cluster (datastore-*)' do
 
         expect {
           cpi.create_disk(2048, {}, nil)
-        }.to raise_error(/Datastores matching criteria are in maintenance mode. No valid placement found/)
+        }.to raise_error(/No valid placement found for disks/)
       end
     end
   end

--- a/src/vsphere_cpi/spec/integration/host_maintenance_mode_spec.rb
+++ b/src/vsphere_cpi/spec/integration/host_maintenance_mode_spec.rb
@@ -73,7 +73,7 @@ describe 'Give a cluster with DRS On ', host_maintenance: true  do
     end
   end
 
-  context 'when regex matches one or more of datastores that are accessible by all maintenace mode hosts in a cluster (datastore-*) ' do
+  context 'when regex matches one or more of datastores that are accessible by all maintenance mode hosts in a cluster (datastore-*) ' do
     let(:vm_type) do
       {
           'ram' => 512,
@@ -121,7 +121,7 @@ describe 'Give a cluster with DRS On ', host_maintenance: true  do
       begin
         expect do
           cpi.create_disk(2048, {}, nil)
-        end.to raise_error(/No valid placement found due to no active host/)
+        end.to raise_error(/No valid placement found/)
       end
     end
     after do
@@ -129,7 +129,7 @@ describe 'Give a cluster with DRS On ', host_maintenance: true  do
     end
   end
 
-  context 'when regex matches one or more of datastores that are accessible by all maintenace mode hosts in other cluster (datastore-*) ' do
+  context 'when regex matches one or more of datastores that are accessible by all maintenance mode hosts in other cluster (datastore-*) ' do
     let(:vm_type) do
       {
           'ram' => 512,

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -1502,12 +1502,13 @@ module VSphereCloud
       before do
         allow(ds_mob).to receive_message_chain('summary.maintenance_mode').and_return("normal")
       end
+      let(:accessible) { true }
       let(:host_runtime_info) { instance_double(VimSdk::Vim::Host::RuntimeInfo, in_maintenance_mode: false) }
       let(:host_system) {instance_double(VimSdk::Vim::HostSystem, runtime: host_runtime_info)}
       let(:datastore_host_mount) { [instance_double('VimSdk::Vim::Datastore::HostMount', key: host_system)]}
       let(:ds_mob) { instance_double('VimSdk::Vim::Datastore', host: datastore_host_mount) }
-      let(:small_ds) { instance_double(VSphereCloud::Resources::Datastore, free_space: 2048, mob: ds_mob, accessible?: true) }
-      let(:large_ds) { instance_double(VSphereCloud::Resources::Datastore, free_space: 4096, mob: ds_mob, accessible?: true) }
+      let(:small_ds) { instance_double(VSphereCloud::Resources::Datastore, free_space: 2048, mob: ds_mob, accessible?: accessible) }
+      let(:large_ds) { instance_double(VSphereCloud::Resources::Datastore, free_space: 4096, mob: ds_mob, accessible?: accessible) }
       let(:accessible_datastores) do
         {
           'small-ds' => small_ds,
@@ -1634,6 +1635,15 @@ module VSphereCloud
           disk_cid = vsphere_cloud.create_disk(1024, cloud_properties)
 
           expect(disk_cid).to eq("fake-disk-cid.#{expected_pattern}")
+        end
+      end
+
+      context 'when datastores are not accessible from any host' do
+        let(:accessible) { false }
+        it 'raises an error' do
+          expect {
+            vsphere_cloud.create_disk(1024, {})
+          }.to raise_error(/Datastores matching criteria are in maintenance mode or not accessible/)
         end
       end
     end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cluster_picker_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cluster_picker_spec.rb
@@ -67,7 +67,7 @@ module VSphereCloud
 
         context 'when all hosts are in maintenance mode' do
           let(:host_runtime_info) { instance_double(VimSdk::Vim::Host::RuntimeInfo, in_maintenance_mode: true) }
-          it 'returns the no active host exception' do
+          it 'raises the error' do
             disks = [
                 instance_double(VSphereCloud::DiskConfig,
                                 size: 256,
@@ -87,7 +87,7 @@ module VSphereCloud
 
             expect do
               picker.best_cluster_placement(req_memory: 1024, disk_configurations: disks)
-            end.to raise_error(/No valid placement found due to no active host/)
+            end.to raise_error(/No valid placement found/)
           end
         end
 
@@ -128,6 +128,7 @@ module VSphereCloud
       context 'when no cluster fits' do
         before do
           allow(not_matching_ds.mob).to receive_message_chain('summary.maintenance_mode').and_return("normal")
+          allow(not_matching_ds).to receive(:accessible_from?).with(any_args).and_return(true)
         end
         let(:available_clusters) { [cluster_1] }
         let(:cluster_1) do

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cluster_picker_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cluster_picker_spec.rb
@@ -37,21 +37,22 @@ module VSphereCloud
 
         context 'when at least few hosts are not in maintenance mode' do
           let(:host_runtime_info) { instance_double(VimSdk::Vim::Host::RuntimeInfo, in_maintenance_mode: false) }
-          it 'returns the first placement option' do
-            disks = [
+          let(:disks) {
+            [
               instance_double(VSphereCloud::DiskConfig,
-                size: 256,
-                target_datastore_pattern: 'target-ds',
-                existing_datastore_name: nil
+                              size: 256,
+                              target_datastore_pattern: 'target-ds',
+                              existing_datastore_name: nil
               ),
               instance_double(VSphereCloud::DiskConfig,
-                size: 256,
-                ephemeral?: true,
-                target_datastore_pattern: 'target-ds',
-                existing_datastore_name: nil
+                              size: 256,
+                              ephemeral?: true,
+                              target_datastore_pattern: 'target-ds',
+                              existing_datastore_name: nil
               ),
             ]
-
+          }
+          it 'returns the first placement option' do
             picker = ClusterPicker.new(0, 0)
             picker.update(available_clusters)
 
@@ -62,6 +63,17 @@ module VSphereCloud
                 disks[1] => 'target-ds',
               }
             })
+          end
+          context 'when all datastores are not accessible' do
+            it 'raises an error' do
+              expect(target_ds).to receive(:accessible_from?).with(cluster_1).and_return(false)
+              picker = ClusterPicker.new(0, 0)
+              picker.update(available_clusters)
+
+              expect {
+                picker.best_cluster_placement(req_memory: 1024, disk_configurations: disks)
+              }.to raise_error(/No valid placement found/)
+            end
           end
         end
 
@@ -85,9 +97,9 @@ module VSphereCloud
             picker = ClusterPicker.new(0, 0)
             picker.update(available_clusters)
 
-            expect do
+            expect {
               picker.best_cluster_placement(req_memory: 1024, disk_configurations: disks)
-            end.to raise_error(/No valid placement found/)
+            }.to raise_error(/No valid placement found/)
           end
         end
 
@@ -97,7 +109,7 @@ module VSphereCloud
           let(:active_host_system) {instance_double(VimSdk::Vim::HostSystem, runtime: active_host_runtime_info)}
           let(:datastore_host_mount) { [instance_double('VimSdk::Vim::Datastore::HostMount', key: active_host_system),
                                         instance_double('VimSdk::Vim::Datastore::HostMount', key: host_system)]}
-          it 'returns the no active host exception' do
+          it 'raises the error' do
             disks = [
                 instance_double(VSphereCloud::DiskConfig,
                                 size: 256,
@@ -115,11 +127,9 @@ module VSphereCloud
             picker = ClusterPicker.new(0, 0)
             picker.update(available_clusters)
 
-            expect do
-              picker.best_cluster_placement(req_memory: 1024, disk_configurations: disks).to
-                raise_error(/No valid placement found due to no active host /)
-            end
-
+            expect {
+              picker.best_cluster_placement(req_memory: 1024, disk_configurations: disks)
+            }.to raise_error(/No valid placement found for disks/)
           end
         end
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/datastore_picker_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/datastore_picker_spec.rb
@@ -378,6 +378,10 @@ module VSphereCloud
           sorted_datastores = available_datastores.sort do |x, y|
             y[1].free_space <=> x[1].free_space
           end
+          puts 'Summary of simulated placements'
+          sorted_datastores.each do |ds|
+            print "#{ds[0]}: free_space => #{ds[1].free_space}, disk_counts => #{disk_counts_hash[ds[0]]}\n"
+          end
         end
       end
     end


### PR DESCRIPTION
- Filter inaccessible datastore (not accessible from any host) before
calling datastore picker.
- Change cluster_picker, create_disk and reattach_disk to filter as per
above criteria.
- Datastore picker now only selects one possible datastore for each disk.
- Fix Unit tests
- Fix Integration tests

#108 

[Delivers #158039615](https://www.pivotaltracker.com/story/show/158039615)

Signed-off-by: Neha Jain <jneha@vmware.com>