### PR TITLE
Make setup_env_proxy immune to close ssh socket failure

### DIFF
--- a/ci/shared/tasks/setup-env-proxy.sh
+++ b/ci/shared/tasks/setup-env-proxy.sh
@@ -20,7 +20,7 @@ sshpass -p 'vcpi' ssh -o StrictHostKeyChecking=no -M -S "$sockpath" -4 -D 5000 -
 
 # Ensure tmpdir and control socket are cleaned up on exit
 master_exit() {
-  ssh -S "$sockpath" -O exit "$jumpbox_remote" &> /dev/null
+  ssh -S "$sockpath" -O exit "$jumpbox_remote" &> /dev/null || true
   rm -rf "$tmpdir"
 }
 trap master_exit EXIT


### PR DESCRIPTION
- On a concourse container it is increasingly noticed that ssh socket
connection fails to close cleanly and results in script exiting with non
zero status due to set -e flag. This commit disables the set -e and
forces the ssh socket closure command to return 0 status.