### PR TITLE
Replace bosh_cpi_networking with bosh_cpi gem

### DIFF
--- a/src/vsphere_cpi/Gemfile
+++ b/src/vsphere_cpi/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'bosh_common', '1.3262.24.0'
-gem 'bosh_cpi_networking'
+gem 'bosh_cpi',    '2.5.0'
 gem 'builder',     '~> 3.2.3'
 gem 'json',        '~> 2.1', '>= 2.1.0'
 gem 'membrane',    '~> 1.1.0'

--- a/src/vsphere_cpi/Gemfile.lock
+++ b/src/vsphere_cpi/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     bosh_common (1.3262.24.0)
       logging (~> 1.8.2)
       semi_semantic (~> 1.2.0)
-    bosh_cpi_networking (2.7)
+    bosh_cpi (2.5.0)
       httpclient (~> 2.8.3)
       membrane (~> 1.1.0)
     builder (3.2.3)
@@ -80,7 +80,7 @@ PLATFORMS
 
 DEPENDENCIES
   bosh_common (= 1.3262.24.0)
-  bosh_cpi_networking
+  bosh_cpi (= 2.5.0)
   builder (~> 3.2.3)
   fakefs
   json (~> 2.1, >= 2.1.0)

--- a/src/vsphere_cpi/bin/vsphere_cpi
+++ b/src/vsphere_cpi/bin/vsphere_cpi
@@ -21,7 +21,8 @@ Bosh::Clouds::Config.configure(OpenStruct.new(
 
 soap_log = StringIO.new
 
-cpi_lambda = lambda do |context|
+#cpi_lambda now requires 2 arguments context, cpi_api_version
+cpi_lambda = lambda do |context, _|
   unless cpi_config.has_key?('cloud') && cpi_config['cloud'].has_key?('properties')
     raise "Could not find cloud properties in the configuration"
   end


### PR DESCRIPTION
- bump bosh-cpi version to 2.5.0
- Add 1 more argument to cpi_lambda, which is now required by bosh_cpi
  2.5.0 to support multiple cpi versions