### PR TITLE
Add distribution test in CI pipeline.

### DIFF
--- a/ci/pipeline/main.yml.erb
+++ b/ci/pipeline/main.yml.erb
@@ -124,6 +124,83 @@ jobs:
       - put: pool-6.5
         params : {release: pool-6.5}
 
+
+  - name: lock-distribution-test
+    plan:
+      - aggregate:
+        - get: source-ci
+        - get: bosh-cpi-src
+          passed: [bats]
+        - get: bosh-cpi-artifacts
+          trigger: true
+          passed: [bats]
+      - do:
+        - put: environment
+          resource: pool-6.5
+          params: {acquire: true}
+        - task: extend-lease-6.5
+          file: source-ci/ci/tasks/extend-lease.yml
+          params:
+            DBCUSER: {{dbc_user}}
+            DBCHOST: {{dbc_host}}
+            DBC_SSH_KEY: {{dbc_key}}
+          on_failure:
+            put: pool-6.5
+            params : {release: environment}
+        attempts: 4
+
+  - name: distribution-test
+    serial: true
+    plan:
+      - aggregate:
+        - get: source-ci
+        - {get: cpi-release,              trigger: false, resource: bosh-cpi-artifacts, passed: [lock-distribution-test]}
+        - {get: environment,              trigger: true,  passed: [lock-distribution-test], resource: pool-6.5 }
+        - {get: bosh-release,             trigger: false, resource: old-bosh-release}
+        - {get: stemcell,                 trigger: false, resource: old-stemcell}
+        - {get: certification,            trigger: false}
+        - {get: bosh-deployment,          trigger: false}
+        - {get: bats,                     trigger: false}
+        - {get: bosh-cli,                 trigger: false}
+        - {get: bosh-cpi-src,             trigger: false, passed: [lock-distribution-test]}
+      - task: prepare-director
+        file: source-ci/ci/tasks/prepare-director.yml
+        params:
+          OPTIONAL_OPS_FILE:  |
+            -o certification/shared/assets/ops/redis.yml
+            -o certification/shared/assets/ops/remove-hm.yml
+            -o bosh-deployment/vsphere/resource-pool.yml
+            -o certification/shared/assets/ops/remove-provider-cert.yml
+      - do:
+        - task: deploy-director
+          file: source-ci/ci/tasks/deploy-director.yml
+        - task: run-distribution-test
+          file: source-ci/ci/tasks/run-distribution-test.yml
+        on_failure:
+          aggregate:
+          - put: pool-6.5
+            params : {remove: environment}
+          - put: notify
+            params:
+              username: 'CPI-Doctor'
+              text: |
+                The distribution test failed. Check it out at: https://ci.vcna.io/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+        ensure:
+          do:
+            - task: teardown
+              file: source-ci/ci/tasks/teardown.yml
+      - put: notify
+        params:
+          username: 'CPI-Doctor'
+          text: |
+            The distribution tests passed. Check it out at: https://ci.vcna.io/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
+  - name: unlock-distribution-test
+    plan:
+      - {trigger: true, passed: [distribution-test], get: pool-6.5}
+      - put: pool-6.5
+        params : {release: pool-6.5}
+
   - name: delivery
     plan:
     - aggregate:
@@ -146,9 +223,9 @@ jobs:
     - aggregate:
       - get: source-ci
       - get: bosh-cpi-artifacts
-        passed: [bats]
+        passed: [distribution-test]
       - get: bosh-cpi-src
-        passed: [bats]
+        passed: [distribution-test]
       - get: release-version-semver
         params: { bump: major }
     - task: inspect
@@ -350,6 +427,10 @@ groups:
   - lifecycle-6.0-NSXV
   - lock-6.0-NSXV
   - unlock-6.0-NSXV
+  - lock-distribution-test
+  - distribution-test
+  - unlock-distribution-test
+
 
 - name: Delivery
   jobs:
@@ -369,7 +450,6 @@ groups:
   - bats
   - lock-bats
   - unlock-bats
-
 
 - name: v6.5
   jobs:

--- a/ci/shared/distribution-test-cloud-config.yml
+++ b/ci/shared/distribution-test-cloud-config.yml
@@ -1,0 +1,48 @@
+azs:
+- cloud_properties:
+    datacenters:
+    - clusters:
+      - vcpi-cluster-1: {}
+      - vcpi-cluster-2: {}
+  name: z1
+compilation:
+  az: z1
+  network: default
+  reuse_compilation_vms: true
+  vm_type: large
+  workers: 3
+disk_types:
+- cloud_properties:
+    datastores: [nfs0-1]
+  disk_size: 3000
+  name: default
+- cloud_properties:
+    datastores: [nfs0-1]
+  disk_size: 50000
+  name: large
+networks:
+- name: default
+  subnets:
+  - azs:
+    - z1
+    cloud_properties:
+      name: VM Network
+    dns:
+    - 192.168.111.1
+    gateway: 192.168.111.1
+    range: 192.168.111.0/24
+    reserved: [192.168.111.0-192.168.111.152]
+  type: manual
+vm_types:
+- cloud_properties:
+    cpu: 2
+    datastores: [isc-cl1-ds-0, isc-cl2-ds-0]
+    disk: 8192
+    ram: 512
+  name: default
+- cloud_properties:
+    cpu: 2
+    datastores: [isc-cl1-ds-0, isc-cl2-ds-0]
+    disk: 30240
+    ram: 2048
+  name: large

--- a/ci/shared/distribution-test-deployment-manifest.yml
+++ b/ci/shared/distribution-test-deployment-manifest.yml
@@ -1,0 +1,34 @@
+---
+name: zookeeper
+
+releases:
+- name: zookeeper
+  version: 0.0.5
+  url: https://bosh.io/d/github.com/cppforlife/zookeeper-release?v=0.0.5
+  sha1: 65a07b7526f108b0863d76aada7fc29e2c9e2095
+
+stemcells:
+- alias: default
+  os: ubuntu-trusty
+  version: latest
+
+update:
+  canaries: 1
+  max_in_flight: 1
+  stemcell: default
+  canary_watch_time: 5000-60000
+  update_watch_time: 5000-60000
+
+instance_groups:
+- name: instance-zoo
+  azs: [z1]
+  instances: 35
+  jobs:
+  - name: zookeeper
+    release: zookeeper
+    properties: {}
+  stemcell: default
+  vm_type:  default
+  persistent_disk_pool: default
+  networks:
+  - name: default

--- a/ci/shared/scripts/vm_stats.rb
+++ b/ci/shared/scripts/vm_stats.rb
@@ -1,0 +1,53 @@
+$LOAD_PATH.unshift File.expand_path( '../../../../../bosh-cpi-src/src/vsphere_cpi/lib', __FILE__)
+
+require 'yaml'
+require 'json'
+require 'ostruct'
+require 'logger'
+require 'tmpdir'
+require 'bosh/cpi'
+require 'cloud'
+require 'cloud/vsphere'
+
+Bosh::Clouds::Config.configure(OpenStruct.new(
+  logger: Bosh::Cpi::Logger.new(STDOUT),
+  task_checkpoint: nil,
+))
+
+cpi_options = {'agent'=>{'ntp'=>['10.80.0.44']},
+  'vcenters'=>
+    [{'host'=>"#{ENV['BOSH_VSPHERE_CPI_HOST']}",
+      'user'=>"#{ENV['BOSH_VSPHERE_CPI_USER']}",
+      'password'=>"#{ENV['BOSH_VSPHERE_CPI_PASSWORD']}",
+      'default_disk_type'=>'preallocated',
+      'datacenters'=>
+        [{'name'=>'vcpi-dc',
+          'vm_folder'=>'vcpi-vm-folder',
+          'template_folder'=>'vcpi-vm-folder',
+          'disk_path'=>'vcpi-disk-folder',
+          'datastore_pattern'=>'isc-cl1-ds-1',
+          'persistent_datastore_pattern'=>'isc-cl1-ds-1',
+          'allow_mixed_datastores'=>true,
+          'clusters'=>[{'vcpi-cluster-1'=>{}}, {'vcpi-cluster-2'=>{}}]}],
+      'http_logging'=>false,
+      'request_id'=>nil}]}
+
+cpi = VSphereCloud::Cloud.new(cpi_options)
+datacenter = cpi.datacenter
+
+cluster_counter = []
+ds_counter = []
+File.readlines(ARGV[0]).map do |line|
+  cpi.client.find_vm_by_name(datacenter.mob, line.strip)
+end.compact.each do |vm|
+  cluster_counter << vm.runtime.host.parent.name
+  ds_counter << vm.datastore
+end
+ds_counter = ds_counter.flatten.map{|ds| ds.name}.inject(Hash.new(0)) { |total, e| total[e] += 1 ;total}
+cluster_counter = cluster_counter.inject(Hash.new(0)) { |total, e| total[e] += 1 ;total}
+
+puts "************************SUMMARY**************************"
+puts "Printing VM distribution summary"
+puts "DS Summary : #{ds_counter}"
+puts "Cluster Summary #{cluster_counter}"
+puts "*********************************************************"

--- a/ci/tasks/prepare-director.sh
+++ b/ci/tasks/prepare-director.sh
@@ -16,7 +16,7 @@ set -e
 # from the managed object representing the nfs0-1 datastore inside
 # *vcpi-dc-nested*. In this case a regular expression matching nfs0-1 will
 # resolve to both managed objects thus causing the aforementioned error.
-unambiguous_ds=isc-cl1-ds-1
+unambiguous_ds=nfs0-1
 
 source environment/metadata
 

--- a/ci/tasks/run-distribution-test.sh
+++ b/ci/tasks/run-distribution-test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Setup connection on proxy
+source source-ci/ci/shared/tasks/setup-env-proxy.sh
+
+# Setup bosh director connection environment and aliases
+source director-state/director.env
+export BOSH_PRIVATE_KEY="$(bosh int director-state/creds.yml --path=/jumpbox_ssh/private_key)"
+export BOSH_STEMCELL=$(realpath stemcell/*.tgz)
+
+ssh_key_path=/tmp/bat_private_key
+echo "$BOSH_PRIVATE_KEY" > $ssh_key_path
+chmod 600 $ssh_key_path
+export BOSH_GW_PRIVATE_KEY=$ssh_key_path
+
+# Deploy zookeeper release
+bosh -n ucc source-ci/ci/shared/distribution-test-cloud-config.yml
+bosh -n upload-stemcell $BOSH_STEMCELL
+bosh -n -d zookeeper deploy source-ci/ci/shared/distribution-test-deployment-manifest.yml
+
+# Filter out the vm names
+bosh vms | grep 'vm-' | awk '{print $5}' > tmp_out.out
+
+pushd bosh-cpi-src/src/vsphere_cpi
+  bosh vms | grep 'vm-' | awk '{print $5}' > tmp_out.out
+  bundle install
+  bundle exec ruby ../../../source-ci/ci/shared/scripts/vm_stats.rb tmp_out.out
+  rm tmp_out.out
+popd
+
+# Delete the deployment
+bosh -n delete-deployment -d zookeeper

--- a/ci/tasks/run-distribution-test.yml
+++ b/ci/tasks/run-distribution-test.yml
@@ -1,0 +1,15 @@
+platform: linux
+image_resource:
+  { type: docker-image, source: { repository: vcpici/vcpi-main } }
+
+inputs:
+  - name: source-ci
+  - name: certification
+  - name: environment
+  - name: bosh-cpi-src
+  - name: director-state
+  - name: bosh-cli
+  - name: stemcell
+
+run:
+  path: source-ci/ci/tasks/run-distribution-test.sh


### PR DESCRIPTION
Deploys 35 zookeeper VMs across two clusters and prints the distribution of compute and datastore locations for 35 VMs.

The job is triggered after BATS run and is not a pass/fail job.

The job is intended to just print distribution statistics and always pass. 