### PR TITLE
Use vcenter.host key to set vcenter host property

### DIFF
--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -15,8 +15,10 @@ packages:
 - vsphere_cpi
 
 properties:
-  vcenter.address:
+  vcenter.host:
     description: Address of vCenter server used by vsphere cpi
+  vcenter.address:
+    description: Address of vCenter server used by vsphere cpi if not set by `vcenter.host`
   vcenter.default_disk_type:
     description: backing for ephemeral and persistent disks unless overridden by `disk_pools.cloud_properties.type`; can be `thin` or `preallocated`
     default: preallocated

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -1,4 +1,14 @@
 <%=
+  vcenter_host = nil
+
+  if_p('vcenter.host') do
+    vcenter_host = p('vcenter.host')
+  end
+
+  # Use vcenter.address if vcenter.host is not set
+  if_p('vcenter.address') do
+    vcenter_host = p('vcenter.address') if vcenter_host.nil?
+  end
 
   params = {
     "cloud" => {
@@ -6,7 +16,7 @@
       "properties" => {
         "vcenters" => [
           {
-            "host" => p('vcenter.address'),
+            "host" => vcenter_host,
             "user" => p('vcenter.user'),
             "password" => p('vcenter.password'),
             "datacenters" => [],

--- a/src/vsphere_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/vsphere_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -19,7 +19,7 @@ describe 'cpi.json.erb' do
     {
       'properties' => {
         'vcenter' => {
-          'address' => 'vcenter-address',
+          'host' => 'vcenter-address',
           'user' => 'vcenter-user',
           'password' => 'vcenter-password',
           'enable_auto_anti_affinity_drs_rules' => true,
@@ -114,6 +114,29 @@ describe 'cpi.json.erb' do
       expect(subject['cloud']['properties']['vcenters'].first['nsx']['address']).to eq('my-nsx-manager')
       expect(subject['cloud']['properties']['vcenters'].first['nsx']['user']).to eq('my-nsx-user')
       expect(subject['cloud']['properties']['vcenters'].first['nsx']['password']).to eq('fake')
+    end
+  end
+
+  context 'when vcenter address is also set' do
+    before(:each) {
+      manifest['properties']['vcenter'].merge!({
+        'address' => 'vcenter-new-address'
+      })
+    }
+    it 'uses the host key to set the vcenter host value' do
+      expect(subject['cloud']['properties']['vcenters'].first['host']).to eq('vcenter-address')
+    end
+  end
+
+  context 'when vcenter address is set and vcenter host is not set' do
+    before(:each) {
+      manifest['properties']['vcenter'].merge!({
+        'address' => 'vcenter-new-address',
+        'host' => nil
+      })
+    }
+    it 'uses the address key to set vcenter host value' do
+      expect(subject['cloud']['properties']['vcenters'].first['host']).to eq('vcenter-new-address')
     end
   end
 


### PR DESCRIPTION
- Fallback to vcenter.address for backward compatibility

[#160008312](https://www.pivotaltracker.com/story/show/160008312)