### PR TITLE
Uploads/Downloads agent files via a host.

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/agent_env.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/agent_env.rb
@@ -5,10 +5,9 @@ module VSphereCloud
     include VimSdk
     include Logger
 
-    def initialize(client:, file_provider:, cloud_searcher:)
+    def initialize(client:, file_provider:)
       @client = client
       @file_provider = file_provider
-      @cloud_searcher = cloud_searcher
     end
 
     def get_current_env(vm, datacenter_name)
@@ -17,13 +16,13 @@ module VSphereCloud
       env_iso_folder = env_iso_folder(cdrom)
       return unless env_iso_folder
 
-      datastore_name = cdrom.backing.datastore.name
-      datastore_pattern = Regexp.escape(datastore_name)
+      datastore = cdrom.backing.datastore
+      datastore_pattern = Regexp.escape(datastore.name)
       result = env_iso_folder.match(/\[#{datastore_pattern}\] (.*)/)
-      raise Bosh::Clouds::CloudError.new("Could not find matching datastore name '#{datastore_name}'") unless result
+      raise Bosh::Clouds::CloudError.new("Could not find matching datastore name '#{datastore.name}'") unless result
       env_path = result[1]
 
-      contents = @file_provider.fetch_file_from_datastore(datacenter_name, datastore_name, "#{env_path}/env.json")
+      contents = @file_provider.fetch_file_from_datastore(datacenter_name, datastore, "#{env_path}/env.json")
       raise Bosh::Clouds::CloudError.new("Unable to load env.json from '#{env_path}/env.json'") unless contents
 
       JSON.load(contents)
@@ -35,13 +34,18 @@ module VSphereCloud
 
       disconnect_cdrom(vm)
       clean_env(vm)
-      @file_provider.upload_file_to_datastore(location[:datacenter], location[:datastore], "#{location[:vm]}/env.json", env_json)
-      @file_provider.upload_file_to_datastore(location[:datacenter], location[:datastore], "#{location[:vm]}/env.iso", generate_env_iso(env_json))
+      @file_provider.upload_file_to_datastore(location[:datacenter],
+                                              location[:datastore].mob,
+                                              "#{location[:vm]}/env.json",
+                                              env_json)
 
-      datastore = @cloud_searcher.get_managed_object(Vim::Datastore, name: location[:datastore])
-      file_name = "[#{location[:datastore]}] #{location[:vm]}/env.iso"
+      @file_provider.upload_file_to_datastore(location[:datacenter],
+                                              location[:datastore].mob,
+                                              "#{location[:vm]}/env.iso",
+                                              generate_env_iso(env_json))
 
-      update_cdrom_env(vm, datastore, file_name)
+      file_name = "[#{location[:datastore].name}] #{location[:vm]}/env.iso"
+      update_cdrom_env(vm, location[:datastore].mob, file_name)
     end
 
     def env_iso_folder(cdrom_device)

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -77,13 +77,13 @@ module VSphereCloud
         cluster_provider: @cluster_provider
       )
       @file_provider = FileProvider.new(
+        client: @client,
         http_client: @http_client,
         vcenter_host: @config.vcenter_host
       )
       @agent_env = AgentEnv.new(
         client: client,
         file_provider: @file_provider,
-        cloud_searcher: @cloud_searcher
       )
 
       if @config.nsxt_enabled?
@@ -792,21 +792,21 @@ module VSphereCloud
       info.entity
     end
 
-    def get_vm_env_datastore_name(vm)
+    def get_vm_env_datastore(vm)
       cdrom = @client.get_cdrom_device(vm.mob)
-      cdrom.backing.datastore.name
+      vm.accessible_datastores[cdrom.backing.datastore.name]
     end
 
     def add_disk_to_agent_env(vm, director_disk_cid, device_unit_number)
       env = @agent_env.get_current_env(vm.mob, @datacenter.name)
       env['disks']['persistent'][director_disk_cid.raw] = device_unit_number.to_s
-      location = { datacenter: @datacenter.name, datastore: get_vm_env_datastore_name(vm), vm: vm.cid }
+      location = { datacenter: @datacenter.name, datastore: get_vm_env_datastore(vm), vm: vm.cid }
       @agent_env.set_env(vm.mob, location, env)
     end
 
     def delete_disk_from_agent_env(vm, director_disk_cid)
       env = @agent_env.get_current_env(vm.mob, @datacenter.name)
-      location = { datacenter: @datacenter.name, datastore: get_vm_env_datastore_name(vm), vm: vm.cid }
+      location = { datacenter: @datacenter.name, datastore: get_vm_env_datastore(vm), vm: vm.cid }
 
       if env['disks']['persistent'][director_disk_cid.raw]
         env['disks']['persistent'].delete(director_disk_cid.raw)

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -139,11 +139,11 @@ module VSphereCloud
           env = @cpi.generate_agent_env(vm_config.name, created_vm.mob, vm_config.agent_id, network_env, disk_env)
           env['env'] = vm_config.agent_env
 
-          location = {
-            datacenter: @datacenter.name,
-            datastore: datastore.name,
-            vm: vm_config.name,
-          }
+        location = {
+          datacenter: @datacenter.name,
+          datastore: datastore,
+          vm: vm_config.name,
+        }
 
           @agent_env.set_env(created_vm.mob, location, env)
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/file_provider_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/file_provider_spec.rb
@@ -2,86 +2,194 @@ require 'spec_helper'
 
 module VSphereCloud
   describe FileProvider, fake_logger: true do
-    subject(:file_provider) { described_class.new(http_client: http_client, vcenter_host: vcenter_host, retryer: retryer) }
+    subject(:file_provider) do  described_class.new(client: client,
+      http_client: http_client, vcenter_host: vcenter_host, retryer: retryer)
+    end
 
     let(:http_client) { double('fake-rest-client') }
     let(:vcenter_host) { 'fake-vcenter-host' }
     let(:retryer) { Retryer.new }
-
+    let(:client) { instance_double('VSphereCloud::VCenterClient') }
     let(:datacenter_name) { 'fake-datacenter-name 1' }
-    let(:datastore_name) { 'fake-datastore-name 1' }
     let(:path) { 'fake-path' }
-
+    let(:datastore) {
+      instance_double('VimSdk::Vim::Datastore',name: 'fake-datastore-name 1')
+    }
+    let(:host) { instance_double('VimSdk::Vim::HostSystem', name: 'host')}
+    let(:ticket) {
+      instance_double('VimSdk::Vim::SessionManager::GenericServiceTicket', id: 'ticket')
+    }
     before do
+      allow(file_provider).to receive(:get_healthy_host).with(anything).and_return(host)
+      allow(file_provider).to receive(:get_generic_service_ticket).with(anything).and_return(ticket)
       allow(retryer).to receive(:sleep)
     end
 
     describe '#fetch_file' do
-      it 'gets specified file' do
+      it 'first tries to get file from datastore via a host and succeeds' do
         response_body = double('response_body')
         response = double('response', code: 200, body: response_body)
+        expect(http_client).to receive(:get).with(
+          'https://host/folder/fake-path?'\
+          'dsName=fake-datastore-name%201',
+          {'Cookie' => "vmware_cgi_ticket=ticket"}
+        ).and_return(response)
+
+        expect(
+          file_provider.fetch_file_from_datastore(datacenter_name, datastore, path)
+        ).to eq(response_body)
+      end
+
+      it 'fails to get file via host and retries to get through datacenter and succeeds' do
+        response_body = double('response_body')
+        response = double('response', code: 200, body: response_body)
+
+        expect(http_client).to receive(:get).with(
+          'https://host/folder/fake-path?'\
+          'dsName=fake-datastore-name%201',
+          {'Cookie' => "vmware_cgi_ticket=ticket"}
+        ).exactly(Retryer::MAX_TRIES).times
+         .and_return(double('response', code: 401))
+
         expect(http_client).to receive(:get).with(
           'https://fake-vcenter-host/folder/fake-path?'\
           'dcPath=fake-datacenter-name%201&dsName=fake-datastore-name%201', {}
         ).and_return(response)
 
         expect(
-          file_provider.fetch_file_from_datastore(datacenter_name, datastore_name, path)
+          file_provider.fetch_file_from_datastore(datacenter_name, datastore, path)
         ).to eq(response_body)
+      end
+
+      it 'fails to get file via raises file transfer error' do
+        response_body = double('response_body')
+
+        expect(http_client).to receive(:get).with(
+          'https://host/folder/fake-path?'\
+          'dsName=fake-datastore-name%201',
+          {'Cookie' => "vmware_cgi_ticket=ticket"}
+        ).exactly(Retryer::MAX_TRIES).times
+         .and_return(double('response', code: 401))
+
+        expect(http_client).to receive(:get).with(
+          'https://fake-vcenter-host/folder/fake-path?'\
+          'dcPath=fake-datacenter-name%201&dsName=fake-datastore-name%201', {}
+        ).exactly(Retryer::MAX_TRIES).times
+         .and_return(double('response', code: 401))
+
+        expect {
+          file_provider.fetch_file_from_datastore(datacenter_name, datastore, path)
+        }.to raise_error(VSphereCloud::FileTransferError, /Could not transfer file/)
       end
 
       context 'when the current agent environment does not exist' do
         it 'returns nil' do
           expect(http_client).to receive(:get).with(
+            'https://host/folder/fake-path?'\
+            'dsName=fake-datastore-name%201',
+            {'Cookie' => "vmware_cgi_ticket=ticket"}
+          ).exactly(Retryer::MAX_TRIES).times
+           .and_return(double('response', code: 404))
+
+          expect(http_client).to receive(:get).with(
             'https://fake-vcenter-host/folder/fake-path?'\
-            'dcPath=fake-datacenter-name%201&dsName=fake-datastore-name%201', {}
+          'dcPath=fake-datacenter-name%201&dsName=fake-datastore-name%201', {}
           ).and_return(double('response', code: 404))
 
           expect(
-            file_provider.fetch_file_from_datastore(datacenter_name, datastore_name, path)
+            file_provider.fetch_file_from_datastore(datacenter_name, datastore, path)
           ).to be_nil
         end
       end
 
       context 'when vSphere cannot handle the request' do
         it 'retries then raises an error' do
-          expect(http_client).to receive(:get)
-            .with(
-              'https://fake-vcenter-host/folder/fake-path?'\
-              'dcPath=fake-datacenter-name%201&dsName=fake-datastore-name%201', {}
-            )
-            .exactly(Retryer::MAX_TRIES).times
-            .and_return(double('response', code: 500))
+          expect(http_client).to receive(:get).with(
+            'https://host/folder/fake-path?'\
+            'dsName=fake-datastore-name%201',
+            {'Cookie' => "vmware_cgi_ticket=ticket"}
+          ).exactly(Retryer::MAX_TRIES).times
+           .and_return(double('response', code: 500))
+
+          expect(http_client).to receive(:get).with(
+            'https://fake-vcenter-host/folder/fake-path?'\
+          'dcPath=fake-datacenter-name%201&dsName=fake-datastore-name%201', {}
+          ).exactly(Retryer::MAX_TRIES).times
+           .and_return(double('response', code: 500))
 
           expect {
-            file_provider.fetch_file_from_datastore(datacenter_name, datastore_name, path)
+            file_provider.fetch_file_from_datastore(datacenter_name, datastore, path)
           }.to raise_error(/Could not transfer file/)
         end
       end
     end
 
     describe '#upload_file_to_datastore' do
-      let(:upload_contents) {"fake uplóad contents"}
-      it 'uploads specified file' do
+      let(:upload_contents) {"fake upload contents"}
+      it 'first tries to upload file to datastore via a host and succeeds' do
         response = double('response', code: 200, body: nil)
+        expect(http_client).to receive(:put).with(
+          'https://host/folder/fake-path?'\
+          'dsName=fake-datastore-name%201',
+          upload_contents,
+          { 'Content-Type' => 'application/octet-stream', 'Content-Length' => upload_contents.bytesize,
+            'Cookie' => "vmware_cgi_ticket=ticket"
+          }
+        ).and_return(response)
+
+        file_provider.upload_file_to_datastore(datacenter_name, datastore, path, upload_contents)
+      end
+
+      it 'fails to upload file via host and retries to upload through datacenter and succeeds' do
+        response_body = double('response_body')
+        response = double('response', code: 200, body: response_body)
+
+        expect(http_client).to receive(:put).with(
+          'https://host/folder/fake-path?'\
+          'dsName=fake-datastore-name%201',
+          upload_contents,
+          { 'Content-Type' => 'application/octet-stream', 'Content-Length' => upload_contents.bytesize,
+            'Cookie' => "vmware_cgi_ticket=ticket",
+          }
+        ).exactly(Retryer::MAX_TRIES).times
+         .and_return(double('response', code: 401))
+
         expect(http_client).to receive(:put).with(
           'https://fake-vcenter-host/folder/fake-path?'\
           'dcPath=fake-datacenter-name%201&dsName=fake-datastore-name%201',
           upload_contents,
-          { 'Content-Type' => 'application/octet-stream', 'Content-Length' => upload_contents.bytesize }
+          { 'Content-Type' => 'application/octet-stream',
+            'Content-Length' => upload_contents.bytesize,
+          }
         ).and_return(response)
 
-        file_provider.upload_file_to_datastore(datacenter_name, datastore_name, path, upload_contents)
+        file_provider.upload_file_to_datastore(datacenter_name, datastore, path, upload_contents)
       end
 
       context 'when vSphere cannot handle the request' do
         it 'retries then raises an error' do
-          expect(http_client).to receive(:put)
-            .exactly(Retryer::MAX_TRIES).times
-            .and_return(double('response', code: 500, body: nil))
+
+          expect(http_client).to receive(:put).with(
+            'https://host/folder/fake-path?'\
+            'dsName=fake-datastore-name%201',
+            upload_contents,
+            { 'Content-Type' => 'application/octet-stream',
+              'Content-Length' => upload_contents.bytesize,
+              'Cookie' => "vmware_cgi_ticket=ticket",
+            }
+          ).exactly(Retryer::MAX_TRIES).times.and_return(double('response', code: 500))
+
+          expect(http_client).to receive(:put).with(
+            'https://fake-vcenter-host/folder/fake-path?'\
+            'dcPath=fake-datacenter-name%201&dsName=fake-datastore-name%201',
+            upload_contents,
+            { 'Content-Type' => 'application/octet-stream',
+              'Content-Length' => upload_contents.bytesize,
+            }
+          ).exactly(Retryer::MAX_TRIES).times.and_return(double('response', code: 500))
 
           expect {
-            file_provider.upload_file_to_datastore(datacenter_name, datastore_name, path, upload_contents)
+            file_provider.upload_file_to_datastore(datacenter_name, datastore, path, upload_contents)
           }.to raise_error(/Could not transfer file/)
         end
       end


### PR DESCRIPTION
This change allows datacenter admins to provide read-only access at datacenter level. The file transfer permissions required at Datacenter level are not mandatory. CPI tries to upload a file via a host failing which it falls back to upload/download via datacenter.

- Tries uploading and downloading files to/from datastore through a host
first. It falls back to trying from datacenter if host is not accessible
or thows up any error.

- Adds and updates unit tests

[#158923695](https://www.pivotaltracker.com/story/show/158923695)