### PR TITLE
Fix cluster with 0 datastores bug

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/datastore.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/datastore.rb
@@ -10,6 +10,8 @@ module VSphereCloud
       DISK_HEADROOM = 1024
 
       def self.build_from_client(client, datastore_mob, options={})
+        # datastore_mob can be an empty array or nil. Return empty array immediately
+        return [] if datastore_mob.nil? || datastore_mob.empty?
         ds_properties_map = client.cloud_searcher.get_properties(datastore_mob, Vim::Datastore, Datastore::PROPERTIES, options)
         ds_properties_map.values.map do |ds_properties|
           Datastore.new(

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/cluster_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/cluster_spec.rb
@@ -94,6 +94,21 @@ module VSphereCloud::Resources
         expect(accessible_datastores['ephemeral_1'].name).to eq('ephemeral_1')
         expect(accessible_datastores['ephemeral_2'].name).to eq('ephemeral_2')
       end
+
+      context 'when cluster has access to zero datastores' do
+        let(:properties) do
+          {
+            :obj => cluster_mob,
+            'host' => cluster_hosts,
+            'datastore' => [],
+            'resourcePool' => fake_resource_pool_mob,
+          }
+        end
+        it 'returns the empty list of datastores' do
+          accessible_ds =  cluster.accessible_datastores
+          expect(accessible_ds).to be_empty
+        end
+      end
     end
 
     describe 'cluster utilization' do


### PR DESCRIPTION
- If a cluster is empty or has access zero datastores, the
datastore.build_from_client call from cluster.accessible_datastores
tries to call property collector with an empty array of datastores. This
breaks later when we create a filter spec.

```
      object_spec = obj.collect { |o| PC::ObjectSpec.new(:obj => o, :skip => false) }
      filter_spec = PC::FilterSpec.new(:prop_set => property_specs, :object_set => object_spec)
```

The object spec ends up being empty and filter_spec has empty object
spec which is a required param. This blows up while calling function
retrieve_properties_ex

[#157863595](https://www.pivotaltracker.com/story/show/157863595)