### PR TITLE
Regenerate nsx-t client with updated logical_port_attachment class

### DIFF
--- a/src/vsphere_cpi/Rakefile
+++ b/src/vsphere_cpi/Rakefile
@@ -35,6 +35,7 @@ task :swagger do
   ].join(' ')
 
   #Patch models that have wrong _deserialize method
+  #TODO: Patch both LogicalRouterPortListResult and LogicalPortAttachment in 1 call
   sh [
      "swagger-codegen generate",
      "-i ./data/nsx_api.json",
@@ -42,6 +43,16 @@ task :swagger do
      "-o ./lib/nsxt",
      "-c ./data/config.json -t ./data/swagger-nsxt-template-deserialization",
      "-Dmodels=LogicalRouterPortListResult"
+   ].join(' ')
+
+  #Patch LogicalPortAttachment which also has wrong _deserialize method
+  sh [
+     "swagger-codegen generate",
+     "-i ./data/nsx_api.json",
+     "-l ruby",
+     "-o ./lib/nsxt",
+     "-c ./data/config.json -t ./data/swagger-nsxt-template-deserialization",
+     "-Dmodels=LogicalPortAttachment"
    ].join(' ')
 
   rm_rf (["./lib/nsxt/.swagger-codegen-ignore",

--- a/src/vsphere_cpi/lib/nsxt/nsxt_client/models/logical_port_attachment.rb
+++ b/src/vsphere_cpi/lib/nsxt/nsxt_client/models/logical_port_attachment.rb
@@ -197,6 +197,10 @@ module NSXT
           end
         end
       else # model
+        # If value has resource_type - use it to deserialize
+        unless value[:resource_type].nil?
+          type = value[:resource_type].to_sym
+        end
         temp_model = NSXT.const_get(type).new
         temp_model.build_from_hash(value)
       end

--- a/src/vsphere_cpi/spec/integration/nsxt_spec.rb
+++ b/src/vsphere_cpi/spec/integration/nsxt_spec.rb
@@ -82,7 +82,7 @@ describe 'CPI', nsx_transformers: true do
     end
   end
 
-  describe 'on create_vm', nsxt_2: true do
+  describe 'on create_vm', nsxt_21: true do
     context 'when global default_vif_type is set' do
       let(:cpi) do
         VSphereCloud::Cloud.new(cpi_options(nsxt: {
@@ -98,6 +98,7 @@ describe 'CPI', nsx_transformers: true do
           verify_ports(vm_id) do |lport|
             expect(lport).not_to be_nil
             expect(lport.attachment.context.resource_type).to eq('VifAttachmentContext')
+            expect(lport.attachment.context.vif_type).to eq('PARENT')
           end
         end
       end


### PR DESCRIPTION
- LogicalPortAttachment should take resource_type into account when
deserializing the data

[#160675463](https://www.pivotaltracker.com/story/show/160675463)

# Description

Fixes [#160675463](https://www.pivotaltracker.com/story/show/160675463)

## Impacted Areas in Application
NSX-T

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- integration/nsxt_spec.rb 

