### PR TITLE
Fix inverted select/reject and fix tests to use real types

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -146,10 +146,10 @@ module VSphereCloud
         #   attaching to the same Bus ID. This is unlikely to be triggered using the current disk flows,
         #   but may become an issue if disks can be attached outside the disk creator flow. We may want
         #   to look at VSphereCloud::DrsLock and generalise it.
-        disks = devices.reject { |device| device.is_a?(Vim::Vm::Device::VirtualDisk) }
+        disks = devices.select { |device| device.is_a?(Vim::Vm::Device::VirtualDisk) }
         unit_numbers_by_controller = find_available_unit_numbers_for_each_controller(disks)
 
-        disks = device_changes.select { |device_change| device_change.device.is_a?(VimSdk::Vim::Vm::Device::VirtualDisk) }
+        disks = device_changes.select { |device_change| device_change.device.is_a?(Vim::Vm::Device::VirtualDisk) }
         disks.each do |device_change|
           next unless device_change.device.unit_number.nil?
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/vm_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/vm_spec.rb
@@ -78,14 +78,14 @@ describe VSphereCloud::Resources::VM, fake_logger: true do
     let(:vm_devices) do
       vm_devices = []
       4.times do |i|
-        vm_devices << double(:device, controller_key: 7, unit_number: i, key: -i-1)
+        vm_devices << VimSdk::Vim::Vm::Device::VirtualDisk.new(controller_key: 7, unit_number: i, key: -i-1)
       end
       vm_devices
     end
 
-    let(:device_1) { VimSdk::Vim::Vm::Device::VirtualDevice.new(key: -1) }
-    let(:device_2) { VimSdk::Vim::Vm::Device::VirtualDevice.new(key: -1) }
-    let(:device_3) { VimSdk::Vim::Vm::Device::VirtualDevice.new(key: -1) }
+    let(:device_1) { VimSdk::Vim::Vm::Device::VirtualDisk.new(key: -1) }
+    let(:device_2) { VimSdk::Vim::Vm::Device::VirtualDisk.new(key: -1) }
+    let(:device_3) { VimSdk::Vim::Vm::Device::VirtualDisk.new(key: -1) }
 
     let(:device_changes) do
       [
@@ -109,7 +109,7 @@ describe VSphereCloud::Resources::VM, fake_logger: true do
     let(:vm_devices) do
       vm_devices = []
       4.times do |i|
-        vm_devices << double(:device, controller_key: 7, unit_number: i)
+        vm_devices << VimSdk::Vim::Vm::Device::VirtualDisk.new(controller_key: 7, unit_number: i)
       end
       vm_devices
     end
@@ -126,7 +126,7 @@ describe VSphereCloud::Resources::VM, fake_logger: true do
       let(:vm_devices) do
         vm_devices = []
         7.times do |i|
-          vm_devices << double(:device, controller_key: 7, unit_number: i)
+          vm_devices << VimSdk::Vim::Vm::Device::VirtualDisk.new(controller_key: 7, unit_number: i)
         end
         vm_devices
       end
@@ -143,7 +143,7 @@ describe VSphereCloud::Resources::VM, fake_logger: true do
       let(:vm_devices) do
         vm_devices = []
         7.times do |i|
-          vm_devices << double(:device, controller_key: 7, unit_number: i)
+          vm_devices << VimSdk::Vim::Vm::Device::VirtualDisk.new(controller_key: 7, unit_number: i)
         end
         vm_devices
       end
@@ -160,7 +160,7 @@ describe VSphereCloud::Resources::VM, fake_logger: true do
       let(:vm_devices) do
         vm_devices = []
         64.times do |i|
-          vm_devices << double(:device, controller_key: 7, unit_number: i) if i != 7
+          vm_devices << VimSdk::Vim::Vm::Device::VirtualDisk.new(controller_key: 7, unit_number: i) if i != 7
         end
         vm_devices
       end


### PR DESCRIPTION
# Description

Fixing a bug in #391 where the filter is inverted and it wasnt caught due to excessive mocking in the tests..

## Impacted Areas in Application

VM Creation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [] Unit tests

**Test Configuration**:
* Environment Variables for Integration test:
* Hardware Requirements in ESXi:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
