### PR TITLE
fix migration mode code for vm tags

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -642,12 +642,12 @@ module VSphereCloud
         end
         if @config.nsxt_enabled?
           if @config.nsxt.policy_api_migration_mode?
+            @nsxt_provider.update_vm_metadata_on_logical_ports(vm, metadata)
             begin
               @nsxt_policy_provider.update_vm_metadata_on_segment_ports(vm, metadata)
             rescue VSphereCloud::SegmentPortNotFound => e
-              logger.info("Policy API Migration mode: No Segment Ports found for #{vm_cid} in Policy API, falling back to Manager mode:\n #{e.full_message}")
+              logger.info("Policy API Migration mode: No Segment Ports found for #{vm_cid} in Policy API; metadata set via Manager mode:\n #{e.full_message}")
             end
-            @nsxt_provider.update_vm_metadata_on_logical_ports(vm, metadata)
           elsif @config.nsxt.use_policy_api?
             @nsxt_policy_provider.update_vm_metadata_on_segment_ports(vm, metadata)
           else


### PR DESCRIPTION
# Description

Set tags on ports in manager mode first, so that manager mode changes dont step on the policy mode tags when we set them. Note: this change fixes a race condition in the tests, we think, but the changes are based on observation and speculation about what NSXT might be doing in 3.2, so we aren't positive that we haven't just changed the race condition and not actually fixed it. Since migration mode will eventually go away, we hope this will be good enough.

## Impacted Areas in Application
- policy migration mode

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

integration testing via CI
