### PR TITLE
Run integrations specs in policy and cvds

### DIFF
--- a/ci/config.rb
+++ b/ci/config.rb
@@ -24,7 +24,6 @@ $pipeline.pool('7.0-nsxt32-policy') do |pool|
     RSPEC_FLAGS: [
       '--tag ~nvds',
       '--tag ~host_maintenance',
-      '--tag ~nsxt_all',
     ].join(' ')
   }
 end
@@ -43,7 +42,6 @@ $pipeline.pool('8.0-nsxt42-policy') do |pool|
     RSPEC_FLAGS: [
       '--tag ~nvds',
       '--tag ~host_maintenance',
-      '--tag ~nsxt_all',
     ].join(' ')
   }
 end

--- a/ci/configure.sh
+++ b/ci/configure.sh
@@ -5,4 +5,6 @@ SCRIPT_DIR="$( cd "$( dirname "${0}" )" && pwd )"
 
 export CONCOURSE="${CONCOURSE_TARGET:-bosh-ecosystem}"
 cd "${SCRIPT_DIR}"
-rake pipeline
+
+bundle install
+bundle exec rake pipeline


### PR DESCRIPTION
# Description

Increase the test matrix to run the full suite against more variations of NSXT and vCenter, currently it only runs on vc-7-nsxt-32-nvds. 
