### PR TITLE
Reaarange host group tests for more robustness

### DIFF
--- a/src/vsphere_cpi/spec/integration/vm_host_rule_spec.rb
+++ b/src/vsphere_cpi/spec/integration/vm_host_rule_spec.rb
@@ -465,14 +465,14 @@ describe 'Host Groups in Cluster and VM Host Rules' do
         context 'and one of the cluster has host group and other has resource pool' do
           let(:options) do
             cpi_options(
-                datacenters: [{
-                                  'datastore_pattern' => @datastore_shared_pattern,
-                                  'persistent_datastore_pattern' => @datastore_shared_pattern,
-                                  clusters: [
-                                      { @cluster_name => { host_group: {'name' => @second_host_group, 'drs_rule' => 'Must'} } },
-                                      { @second_cluster_name => { resource_pool: @second_cluster_resource_pool_name, } },
-                                  ]
-                              }]
+              datacenters: [{
+                              'datastore_pattern' => @datastore_shared_pattern,
+                              'persistent_datastore_pattern' => @datastore_shared_pattern,
+                              clusters: [
+                                { @cluster_name => { resource_pool: @first_cluster_second_resource_pool_name, } },
+                                { @second_cluster_name => { host_group: { 'name' => @third_host_group, 'drs_rule' => 'Must' } } },
+                              ]
+                            }]
             )
           end
           let(:cpi) do
@@ -487,35 +487,35 @@ describe 'Host Groups in Cluster and VM Host Rules' do
             (as resource pool has more memory available than host group)' do
             simple_vm_lifecycle(cpi, '', vm_type, get_network_spec) do |vm_id|
               vm = cpi.vm_provider.find(vm_id)
-              expect(vm.cluster).to eq(@second_cluster_name)
+              expect(vm.cluster).to eq(@cluster_name)
             end
             expect(get_count_vm_host_affinity_rules(cluster_mob) +
-                       get_count_vm_host_affinity_rules(second_cluster_mob)).to eq(0)
+                   get_count_vm_host_affinity_rules(second_cluster_mob)).to eq(0)
           end
-          it 'creates multiple VMs (3) one after another on the second cluster\'s resource pool' do
+          it 'creates multiple VMs (3) one after another on the resource pool' do
             vm_list = []
             begin
               3.times do
                 vm_id, _ = cpi.create_vm(
-                    'agent-007',
-                    @stemcell_id,
-                    vm_type,
-                    get_network_spec,
-                    [],
-                    {}
+                  'agent-007',
+                  @stemcell_id,
+                  vm_type,
+                  get_network_spec,
+                  [],
+                  {}
                 )
                 expect(vm_id).to_not be_nil
                 vm_list << vm_id
                 vm = cpi.vm_provider.find(vm_id)
                 expect(vm).to_not be_nil
-                expect(vm.cluster).to eq(@second_cluster_name)
+                expect(vm.cluster).to eq(@cluster_name)
               end
             ensure
               vm_list.each do |vm_id|
                 delete_vm(cpi, vm_id)
               end
               expect(get_count_vm_host_affinity_rules(cluster_mob) +
-                         get_count_vm_host_affinity_rules(second_cluster_mob)).to eq(0)
+                     get_count_vm_host_affinity_rules(second_cluster_mob)).to eq(0)
             end
           end
         end


### PR DESCRIPTION

# Description

Previously the tests for memory capacity used a host group and a resource pool with very similar capacity, which means that in VC8 the tests started failing because nsx-edge is using up some of the memory in the second cluster, changing the outcome of the VM placement. Switching the test around to use a resource pool that is considerably bigger should make the tests more predictable.


## Related PR and Issues
Fixes https://ci-demo.bosh-ecosystem.cf-app.com/teams/main/pipelines/vsphere-cpi/jobs/lifecycle-8.0-nsxt42-cvds/builds/30

## Impacted Areas in Application
none

## Type of change

test fix (no running code changed)

