### PR TITLE
The test was failing as it was choosing the wrong datastore on which to deploy the ephemeral disk for the VM

### DIFF
--- a/src/vsphere_cpi/spec/integration/host_maintenance_mode_spec.rb
+++ b/src/vsphere_cpi/spec/integration/host_maintenance_mode_spec.rb
@@ -6,7 +6,7 @@ describe 'Give a cluster with DRS On ', host_maintenance: true  do
     # We actually use a healthy cluster but manipulate it before the test and restore after we are done
     @cluster_name_maintenance = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_CLUSTER__MAINTENANCE_MODE_HOST')
     @datastore_shared_pattern = fetch_and_verify_datastore('BOSH_VSPHERE_CPI_SHARED_DATASTORE_MAINTENANCE_MODE_HOST', @cluster_name_maintenance)
-    @datastore_pattern_maintenance_cluster = fetch_and_verify_datastore('BOSH_VSPHERE_CPI_DATASTORE_PATTERN_MAINTENANCE_MODE_HOST', @cluster_name_maintenance)
+    @datastore_pattern_maintenance_cluster = fetch_datastore('BOSH_VSPHERE_CPI_DATASTORE_PATTERN_MAINTENANCE_MODE_HOST', @cluster_name_maintenance)
   end
 
   context 'when regex matches one or more of datastores that are accessible by one or few non-maintenance mode hosts in a cluster (datastore-*) ' do

--- a/src/vsphere_cpi/spec/integration/nsxt_spec.rb
+++ b/src/vsphere_cpi/spec/integration/nsxt_spec.rb
@@ -430,7 +430,7 @@ describe 'CPI', nsxt_all: true do
           delete_policy_group(nsgroup_name_1)
         end
 
-        it 'authenticates successfully and creates VM in specified ns groups', focus: true do
+        it 'authenticates successfully and creates VM in specified ns groups' do
           # This test exists primarily to exercise principal identity (cert-based) authentication with
           # the policy API. To do this, we need to add the VM to at least one group to force the CPI
           # to interact with the policy API.

--- a/src/vsphere_cpi/spec/integration/vsan_datastore_spec.rb
+++ b/src/vsphere_cpi/spec/integration/vsan_datastore_spec.rb
@@ -92,7 +92,7 @@ context 'given cpis that are configured to use VSAN datastores', vsan_datastore:
       non_vsan_cpi.cleanup
     end
 
-    it '#attach_disk can move the disk to and from the vsan datastore', focus: true do
+    it '#attach_disk can move the disk to and from the vsan datastore' do
       vsan_cpi.attach_disk(@vm_id, @disk_id)
 
       disk = vsan_cpi.datacenter.find_disk(VSphereCloud::DirectorDiskCID.new(@disk_id))

--- a/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
+++ b/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
@@ -510,11 +510,13 @@ module LifecycleHelpers
     cluster = cpi.client.cloud_searcher.get_managed_object(VimSdk::Vim::ClusterComputeResource, name: cluster_name)
     host_mob_array = cluster.host
     host_mob_array.each do |host_mob|
-      begin
-        cpi.client.wait_for_task do
-          host_mob.exit_maintenance_mode(0)
+      if host_mob.runtime.in_maintenance_mode
+        begin
+          cpi.client.wait_for_task do
+            host_mob.exit_maintenance_mode(0)
+          end
+        rescue VSphereCloud::VCenterClient::TaskException => e
         end
-      rescue VSphereCloud::VCenterClient::TaskException => e
       end
     end
   end

--- a/src/vsphere_cpi/spec/support/lifecycle_properties.rb
+++ b/src/vsphere_cpi/spec/support/lifecycle_properties.rb
@@ -30,14 +30,19 @@ module LifecycleProperties
     )
   end
 
-  def fetch_and_verify_datastore(env_var, cluster_name)
+  def fetch_datastore(env_var, cluster_name)
     datastore_pattern = fetch_property(env_var)
-    datastore = verify_datastore_within_cluster(
+    verify_datastore_within_cluster(
       @lifecycle_cpi,
       env_var,
       datastore_pattern,
       cluster_name
     )
+  end
+
+  def fetch_and_verify_datastore(env_var, cluster_name)
+    datastore_pattern = fetch_property(env_var)
+    datastore = fetch_datastore(env_var, cluster_name)
     verify_datastore_pattern_available_to_all_hosts(
       @lifecycle_cpi,
       env_var,


### PR DESCRIPTION
The test was failing as it was choosing the wrong datastore on which to deploy the ephemeral disk for the VM
# Description

This is a change to a test cleanup block

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

There was a failing concourse pipeline which was failing
https://ci-demo.bosh-ecosystem.cf-app.com/teams/main/pipelines/vsphere-cpi/jobs/lifecycle-7.0-nsxt32-cvds-host-maintenance

# Checklist:

- [ ] My code follows the standard ruby style guide
- [ ] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
