### PR TITLE
fix dns for bats tests

### DIFF
--- a/ci/tasks/prepare-director-policy.sh
+++ b/ci/tasks/prepare-director-policy.sh
@@ -30,6 +30,7 @@ sshpass -p $BOSH_VSPHERE_JUMPER_PASSWORD ssh -o StrictHostKeyChecking=no "vcpi@$
 bosh int \
   -o bosh-deployment/vsphere/cpi.yml \
   -o bosh-deployment/jumpbox-user.yml \
+  -o bosh-deployment/misc/dns.yml \
   -o source-ci/ci/shared/ops/proxy.yml \
   -o source-ci/ci/shared/ops/ntp.yml \
   -o source-ci/ci/shared/ops/use_nsxt_policy_api.yml \
@@ -43,6 +44,7 @@ bosh int \
   -v internal_cidr=30.0.0.0/16 \
   -v internal_gw=30.0.0.1 \
   -v internal_ip=30.0.1.1 \
+  -v internal_dns=192.168.111.1 \
   -v reserved_range=30.0.0.0-30.0.1.0 \
   -v network_name="$BOSH_VSPHERE_VLAN" \
   -v vcenter_dc="$BOSH_VSPHERE_CPI_DATACENTER" \

--- a/ci/tasks/prepare-director.sh
+++ b/ci/tasks/prepare-director.sh
@@ -29,6 +29,7 @@ bosh int \
   -o bosh-deployment/vsphere/cpi.yml \
   -o bosh-deployment/misc/proxy.yml \
   -o bosh-deployment/jumpbox-user.yml \
+  -o bosh-deployment/misc/dns.yml \
   -o source-ci/ci/shared/ops/ntp.yml \
   $OPTIONAL_OPS_FILE \
   -o certification/shared/assets/ops/custom-releases.yml \
@@ -40,6 +41,7 @@ bosh int \
   -v internal_cidr=192.168.111.0/24 \
   -v internal_gw=192.168.111.1 \
   -v internal_ip=192.168.111.152 \
+  -v internal_dns=192.168.111.1 \
   -v reserved_range=192.168.111.2-192.168.111.155 \
   -v network_name="$BOSH_VSPHERE_VLAN" \
   -v vcenter_dc="$BOSH_VSPHERE_CPI_DATACENTER" \


### PR DESCRIPTION
Prevously we ran bosh create-env using the default 8.8.8.8 DNS server, but that dns server is no longer reachable from our testbeds. Use the local testbed DNS server instead.
