### PR TITLE
dns needs to be an array

### DIFF
--- a/ci/tasks/prepare-director-policy.sh
+++ b/ci/tasks/prepare-director-policy.sh
@@ -44,7 +44,7 @@ bosh int \
   -v internal_cidr=30.0.0.0/16 \
   -v internal_gw=30.0.0.1 \
   -v internal_ip=30.0.1.1 \
-  -v internal_dns=192.168.111.1 \
+  -v internal_dns=[192.168.111.1] \
   -v reserved_range=30.0.0.0-30.0.1.0 \
   -v network_name="$BOSH_VSPHERE_VLAN" \
   -v vcenter_dc="$BOSH_VSPHERE_CPI_DATACENTER" \

--- a/ci/tasks/prepare-director.sh
+++ b/ci/tasks/prepare-director.sh
@@ -41,7 +41,7 @@ bosh int \
   -v internal_cidr=192.168.111.0/24 \
   -v internal_gw=192.168.111.1 \
   -v internal_ip=192.168.111.152 \
-  -v internal_dns=192.168.111.1 \
+  -v internal_dns=[192.168.111.1] \
   -v reserved_range=192.168.111.2-192.168.111.155 \
   -v network_name="$BOSH_VSPHERE_VLAN" \
   -v vcenter_dc="$BOSH_VSPHERE_CPI_DATACENTER" \


### PR DESCRIPTION
passing dns as a string value causes bosh create-env to fail