### PR TITLE
Disable new IPv6 tests as the testbed is not setup for them today

### DIFF
--- a/ci/pipeline/main.yml.erb
+++ b/ci/pipeline/main.yml.erb
@@ -178,7 +178,7 @@ jobs:
             image: vcpi-main-image
             params:
               BAT_INFRASTRUCTURE: vsphere
-              BAT_RSPEC_FLAGS:    "--tag ~dns --tag ~vip_networking --tag ~dynamic_networking --tag ~root_partition --tag ~raw_ephemeral_storage"
+              BAT_RSPEC_FLAGS:    "--tag ~dns --tag ~vip_networking --tag ~dynamic_networking --tag ~root_partition --tag ~raw_ephemeral_storage --tag ~ipv6"
               STEMCELL_NAME:      bosh-vsphere-esxi-ubuntu-jammy-go_agent
               JUMPBOX_PRIVATE_KEY: ((nimbus_jumpbox_key.private_key))
               RUBY_GEMS_MIRROR: ((repository_mirrors.rubygems))
@@ -250,7 +250,7 @@ jobs:
           image: vcpi-main-image
           params:
             BAT_INFRASTRUCTURE: vsphere
-            BAT_RSPEC_FLAGS:    "--tag ~dns --tag ~vip_networking --tag ~dynamic_networking --tag ~root_partition --tag ~raw_ephemeral_storage"
+            BAT_RSPEC_FLAGS:    "--tag ~dns --tag ~vip_networking --tag ~dynamic_networking --tag ~root_partition --tag ~raw_ephemeral_storage --tag ~ipv6"
             STEMCELL_NAME:      bosh-vsphere-esxi-ubuntu-jammy-go_agent
             JUMPBOX_PRIVATE_KEY: ((nimbus_jumpbox_key.private_key))
             RUBY_GEMS_MIRROR: ((repository_mirrors.rubygems))
@@ -320,7 +320,7 @@ jobs:
             image: vcpi-main-image
             params:
               BAT_INFRASTRUCTURE: vsphere
-              BAT_RSPEC_FLAGS:    "--tag ~dns --tag ~vip_networking --tag ~dynamic_networking --tag ~root_partition --tag ~raw_ephemeral_storage"
+              BAT_RSPEC_FLAGS:    "--tag ~dns --tag ~vip_networking --tag ~dynamic_networking --tag ~root_partition --tag ~raw_ephemeral_storage --tag ~ipv6"
               STEMCELL_NAME:      bosh-vsphere-esxi-ubuntu-jammy-go_agent
               JUMPBOX_PRIVATE_KEY: ((nimbus_jumpbox_key.private_key))
               RUBY_GEMS_MIRROR: ((repository_mirrors.rubygems))
@@ -390,7 +390,7 @@ jobs:
             image: vcpi-main-image
             params:
               BAT_INFRASTRUCTURE: vsphere
-              BAT_RSPEC_FLAGS:    "--tag ~dns --tag ~vip_networking --tag ~dynamic_networking --tag ~root_partition --tag ~raw_ephemeral_storage"
+              BAT_RSPEC_FLAGS:    "--tag ~dns --tag ~vip_networking --tag ~dynamic_networking --tag ~root_partition --tag ~raw_ephemeral_storage --tag ~ipv6"
               STEMCELL_NAME:      bosh-vsphere-esxi-ubuntu-jammy-go_agent
               JUMPBOX_PRIVATE_KEY: ((nimbus_jumpbox_key.private_key))
               RUBY_GEMS_MIRROR: ((repository_mirrors.rubygems))


### PR DESCRIPTION
# Description

IPv6 was recenetly added to the bats suite but its broken on the vcenter testbeds, so we are going to skip it for now.

## Related PR and Issues
Fixes broken bats tests

## Impacted Areas in Application
List general components of the application that this PR will affect:

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
