### PR TITLE
Set agent env into cloudinit properties

### DIFF
--- a/src/vsphere_cpi/Gemfile
+++ b/src/vsphere_cpi/Gemfile
@@ -7,6 +7,7 @@ gem 'vsphere-automation-cis', '~> 0.4.0'
 gem 'vsphere-automation-vcenter', '~> 0.4.0'
 
 gem 'addressable'
+gem 'base64'
 gem 'builder',     '~> 3.2.3'
 gem 'membrane',    '~> 1.1.0'
 gem 'mono_logger', '~> 1.1.0'

--- a/src/vsphere_cpi/Gemfile.lock
+++ b/src/vsphere_cpi/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ansi (1.5.0)
     ast (2.4.3)
+    base64 (0.3.0)
     bosh_common (1.3262.24.0)
       logging (~> 1.8.2)
       semi_semantic (~> 1.2.0)
@@ -104,6 +105,7 @@ PLATFORMS
 
 DEPENDENCIES
   addressable
+  base64
   bosh_common (= 1.3262.24.0)
   bosh_cpi (= 2.5.0)
   builder (~> 3.2.3)


### PR DESCRIPTION
# Description

This will allow the bosh agent on the VM to fetch its settings using vmtoolsd or vmware-rpctool instead of mounting the CDROM. Follow on PRs for bosh-agent and bosh-linux stemcell-builder will add the agent logic that will consume these properties.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
