### PR TITLE
Use CA for VM tagging when present

### DIFF
--- a/src/vsphere_cpi/bin/vsphere_cpi
+++ b/src/vsphere_cpi/bin/vsphere_cpi
@@ -36,6 +36,9 @@ soap_log = StringIO.new
 cpi_rpc_api_request_raw = ARGF.read
 temp_certificate_files_to_clean_up = []
 
+# PEM in manifest must be non-empty after trim; treat "", whitespace-only, and nil as absent.
+nonempty_pem_string = ->(value) { !value.to_s.strip.empty? }
+
 #cpi_lambda now requires 2 arguments context, cpi_api_version
 cpi_lambda = lambda do |context, _|
   unless cpi_config.has_key?('cloud') && cpi_config['cloud'].has_key?('properties')
@@ -53,27 +56,30 @@ cpi_lambda = lambda do |context, _|
 
   cloud_properties['soap_log'] = soap_log
 
-  if cloud_properties['vcenters'][0].fetch('connection_options', {}).fetch('ca_cert', nil)
+  vcenter_ca = cloud_properties['vcenters'][0].dig('connection_options', 'ca_cert')
+  if nonempty_pem_string.call(vcenter_ca)
     temp = Tempfile.new('vsphere-cpi-vcenter-ca')
-    temp.write(cloud_properties['vcenters'][0]['connection_options']['ca_cert'])
+    temp.write(vcenter_ca.to_s.strip)
     temp.close
 
     temp_certificate_files_to_clean_up << temp
     cloud_properties['vcenters'][0]['connection_options']['ca_cert_file'] = temp.path
   end
 
-  if cloud_properties['vcenters'][0].fetch('nsx', {}).fetch('ca_cert', nil)
+  nsx_ca = cloud_properties['vcenters'][0].dig('nsx', 'ca_cert')
+  if nonempty_pem_string.call(nsx_ca)
     temp = Tempfile.new('vsphere-cpi-nsx-ca')
-    temp.write(cloud_properties['vcenters'][0]['nsx']['ca_cert'])
+    temp.write(nsx_ca.to_s.strip)
     temp.close
 
     temp_certificate_files_to_clean_up << temp
     cloud_properties['vcenters'][0]['nsx']['ca_cert_file'] = temp.path
   end
 
-  if cloud_properties['vcenters'][0].fetch('nsxt', {}).fetch('ca_cert', nil)
+  nsxt_ca = cloud_properties['vcenters'][0].dig('nsxt', 'ca_cert')
+  if nonempty_pem_string.call(nsxt_ca)
     temp = Tempfile.new('vsphere-cpi-nsxt-ca')
-    temp.write(cloud_properties['vcenters'][0]['nsxt']['ca_cert'])
+    temp.write(nsxt_ca.to_s.strip)
     temp.close
 
     temp_certificate_files_to_clean_up << temp

--- a/src/vsphere_cpi/lib/cloud/vsphere/attach_tag_to_vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/attach_tag_to_vm.rb
@@ -92,13 +92,20 @@ module  VSphereCloud
     class AttachTagToVm
       include Logger
       def self.InitializeConnection(cloud_config, logger)
+        ca_file = cloud_config.vcenter_connection_options['ca_cert_file']
         configuration = VSphereAutomation::Configuration.new.tap do |config|
           config.host = cloud_config.vcenter_host
           config.username = cloud_config.vcenter_user
           config.password = cloud_config.vcenter_password
           config.scheme = 'https'
-          config.verify_ssl = false
-          config.verify_ssl_host = false
+          if ca_file
+            config.ssl_ca_cert = ca_file
+            config.verify_ssl = true
+            config.verify_ssl_host = true
+          else
+            config.verify_ssl = false
+            config.verify_ssl_host = false
+          end
           config.logger = logger
           config.debugging = false
         end

--- a/src/vsphere_cpi/lib/cloud/vsphere/attach_tag_to_vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/attach_tag_to_vm.rb
@@ -92,7 +92,9 @@ module  VSphereCloud
     class AttachTagToVm
       include Logger
       def self.InitializeConnection(cloud_config, logger)
-        ca_file = cloud_config.vcenter_connection_options['ca_cert_file']
+        raw = cloud_config.vcenter_connection_options['ca_cert_file']
+        s = raw.to_s.strip
+        ca_file = s.empty? ? nil : s
         configuration = VSphereAutomation::Configuration.new.tap do |config|
           config.host = cloud_config.vcenter_host
           config.username = cloud_config.vcenter_user

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -141,10 +141,6 @@ module VSphereCloud
         @nsxt_policy_provider = NSXTPolicyProvider.new(nsxt_policy_client_builder, @config.nsxt.default_vif_type)
       end
 
-      # Initialize tagging tagger object
-      tag_client = TaggingTag::AttachTagToVm.InitializeConnection(@config, logger)
-      @tagging_tagger = TaggingTag::AttachTagToVm.new(tag_client)
-
       # We get disconnected if the connection is inactive for a long period.
       @heartbeat_thread = Thread.new do
         while true do
@@ -164,6 +160,12 @@ module VSphereCloud
         rescue VSphereCloud::VCenterClient::NotLoggedInException
         end
       end
+    end
+
+    def tagging_tagger
+      @tagging_tagger ||= TaggingTag::AttachTagToVm.new(
+        TaggingTag::AttachTagToVm.InitializeConnection(@config, logger)
+      )
     end
 
     def has_vm?(vm_cid)
@@ -391,7 +393,7 @@ module VSphereCloud
             datacenter: @datacenter,
             agent_env_client: @agent_env,
             additional_agent_env: @config.agent,
-            tagging_tagger: @tagging_tagger,
+            tagging_tagger: tagging_tagger,
             ip_conflict_detector: IPConflictDetector.new(@client, @datacenter),
             ensure_no_ip_conflicts: @config.vcenter_ensure_no_ip_conflicts,
             default_disk_type: @config.vcenter_default_disk_type,

--- a/src/vsphere_cpi/lib/cloud/vsphere/cpi_http_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cpi_http_client.rb
@@ -5,9 +5,12 @@ module VSphereCloud
 
     def initialize(connection_options: {}, http_log: nil)
       # skip SSL verification for backwards compatibility
+      raw = connection_options['ca_cert_file']
+      s = raw.to_s.strip
+      trusted_ca_file = s.empty? ? nil : s
       super(
         http_log: http_log,
-        trusted_ca_file: connection_options['ca_cert_file'],
+        trusted_ca_file: trusted_ca_file,
         ca_cert_manifest_key: 'vcenter.connection_options.ca_cert',
         skip_ssl_verify: true,
       )

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsx_http_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsx_http_client.rb
@@ -1,7 +1,7 @@
 module VSphereCloud
   class NsxHttpClient < BaseHttpClient
     def initialize(user, password, ca_cert_file, http_log = nil)
-      if ca_cert_file.nil?
+      if ca_cert_file.to_s.strip.empty?
         super(
           http_log: http_log,
           skip_ssl_verify: true
@@ -9,7 +9,7 @@ module VSphereCloud
       else
         super(
           http_log: http_log,
-          trusted_ca_file: ca_cert_file,
+          trusted_ca_file: ca_cert_file.to_s.strip,
           ca_cert_manifest_key: 'vcenter.nsx.ca_cert',
           skip_ssl_verify: false
         )

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
@@ -31,11 +31,14 @@ module VSphereCloud
       end
 
       # Root CA Cert
-      configuration.ssl_ca_cert = @config.ca_cert_file
+      raw_ca = @config.ca_cert_file
+      s = raw_ca.to_s.strip
+      ca_file = s.empty? ? nil : s
+      configuration.ssl_ca_cert = ca_file
 
       # SKIP SSL VALIDATION?
-      configuration.verify_ssl = !@config.ca_cert_file.nil?
-      configuration.verify_ssl_host = !@config.ca_cert_file.nil?
+      configuration.verify_ssl = !ca_file.nil?
+      configuration.verify_ssl_host = !ca_file.nil?
 
       @client = NSXT::ApiClient.new(configuration)
       #Design here isn't ideal but allows us to keep "x-allow-overwrite" switching logic out of Swagger generated code.

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_policy_api_client_builder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_policy_api_client_builder.rb
@@ -24,11 +24,14 @@ module VSphereCloud
       end
 
       # Root CA Cert
-      configuration.ssl_ca_cert = @config.ca_cert_file
+      raw_ca = @config.ca_cert_file
+      s = raw_ca.to_s.strip
+      ca_file = s.empty? ? nil : s
+      configuration.ssl_ca_cert = ca_file
 
       # SKIP SSL VALIDATION?
-      configuration.verify_ssl = !@config.ca_cert_file.nil?
-      configuration.verify_ssl_host = !@config.ca_cert_file.nil?
+      configuration.verify_ssl = !ca_file.nil?
+      configuration.verify_ssl_host = !ca_file.nil?
 
       @client = NSXTPolicy::ApiClient.new(configuration)
     end

--- a/src/vsphere_cpi/spec/integration/attach_tag_to_vm_spec.rb
+++ b/src/vsphere_cpi/spec/integration/attach_tag_to_vm_spec.rb
@@ -199,7 +199,12 @@ module VSphereCloud
 
     def tag_client
       return @tag_client unless @tag_client.nil?
-      cloud_config = OpenStruct.new(vcenter_host: @host, vcenter_password: @password, vcenter_user: @user)
+      cloud_config = OpenStruct.new(
+        vcenter_host: @host,
+        vcenter_password: @password,
+        vcenter_user: @user,
+        vcenter_connection_options: {},
+      )
       @tag_client = VSphereCloud::TaggingTag::AttachTagToVm.InitializeConnection(cloud_config, Bosh::Cpi::Logger.new(STDOUT))
     end
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/attach_tag_to_vm_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/attach_tag_to_vm_spec.rb
@@ -62,6 +62,17 @@ module VSphereCloud
             described_class.InitializeConnection(cloud_config, logger)
           end
         end
+
+        context 'when vcenter.connection_options.ca_cert_file is blank' do
+          let(:connection_options) { { 'ca_cert_file' => '' } }
+
+          it 'does not pin a CA and disables TLS verification' do
+            expect(configuration).to receive(:verify_ssl=).with(false)
+            expect(configuration).to receive(:verify_ssl_host=).with(false)
+            expect(configuration).not_to receive(:ssl_ca_cert=)
+            described_class.InitializeConnection(cloud_config, logger)
+          end
+        end
       end
 
       describe '#retrieve_category_id' do

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/attach_tag_to_vm_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/attach_tag_to_vm_spec.rb
@@ -1,12 +1,68 @@
 require 'spec_helper'
 require 'vsphere-automation-cis'
 require 'vsphere-automation-vcenter'
+require 'stringio'
 
 module VSphereCloud
   module TaggingTag
     describe AttachTagToVm, fake_logger: true do
       subject(:api_client) { VSphereAutomation::ApiClient.new }
       subject(:tagging_tag) { TaggingTag::AttachTagToVm.new(api_client) }
+
+      describe '.InitializeConnection' do
+        let(:logger) { ::Logger.new(StringIO.new) }
+        let(:cloud_config) do
+          instance_double(
+            VSphereCloud::Config,
+            vcenter_host: 'vc.example.test',
+            vcenter_user: 'u',
+            vcenter_password: 'p',
+            vcenter_connection_options: connection_options,
+          )
+        end
+        let(:connection_options) { {} }
+        let(:configuration) { instance_double(VSphereAutomation::Configuration) }
+        let(:api_client_instance) { instance_double(VSphereAutomation::ApiClient, default_headers: {}) }
+        let(:session_api) { instance_double(VSphereAutomation::CIS::SessionApi) }
+
+        before do
+          allow(VSphereAutomation::Configuration).to receive(:new).and_return(configuration)
+          allow(configuration).to receive(:tap).and_yield(configuration).and_return(configuration)
+          %i[
+            host=
+            username=
+            password=
+            scheme=
+            verify_ssl=
+            verify_ssl_host=
+            ssl_ca_cert=
+            logger=
+            debugging=
+          ].each { |m| allow(configuration).to receive(m) }
+          allow(configuration).to receive(:basic_auth_token).and_return('Basic x')
+          allow(VSphereAutomation::ApiClient).to receive(:new).with(configuration).and_return(api_client_instance)
+          allow(VSphereAutomation::CIS::SessionApi).to receive(:new).with(api_client_instance).and_return(session_api)
+          allow(session_api).to receive(:create).with('').and_return(double(value: 'session-id'))
+        end
+
+        it 'does not pin a CA and disables TLS verification when ca_cert_file is absent' do
+          expect(configuration).to receive(:verify_ssl=).with(false)
+          expect(configuration).to receive(:verify_ssl_host=).with(false)
+          expect(configuration).not_to receive(:ssl_ca_cert=)
+          described_class.InitializeConnection(cloud_config, logger)
+        end
+
+        context 'when vcenter.connection_options.ca_cert_file is set' do
+          let(:connection_options) { { 'ca_cert_file' => '/tmp/vcenter-ca.pem' } }
+
+          it 'pins the CA and enables TLS verification' do
+            expect(configuration).to receive(:ssl_ca_cert=).with('/tmp/vcenter-ca.pem')
+            expect(configuration).to receive(:verify_ssl=).with(true)
+            expect(configuration).to receive(:verify_ssl_host=).with(true)
+            described_class.InitializeConnection(cloud_config, logger)
+          end
+        end
+      end
 
       describe '#retrieve_category_id' do
         let(:result_1) do

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -108,6 +108,25 @@ module VSphereCloud
       allow(VSphereCloud::AgentEnv).to receive(:new).and_return(agent_env)
     end
 
+    describe '#tagging_tagger' do
+      it 'does not create a CIS tagging REST session until first use' do
+        connect_calls = 0
+        allow(TaggingTag::AttachTagToVm).to receive(:InitializeConnection) do |_cfg, _log|
+          connect_calls += 1
+          tag_client
+        end
+        allow(TaggingTag::AttachTagToVm).to receive(:new).with(tag_client).and_return(tagging_tagger)
+
+        cloud = VSphereCloud::Cloud.new(config)
+        expect(connect_calls).to eq(0)
+
+        cloud.tagging_tagger
+        expect(connect_calls).to eq(1)
+
+        cloud.tagging_tagger
+        expect(connect_calls).to eq(1)
+      end
+    end
 
     describe '#enable_telemetry' do
       before do

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cpi_http_client_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cpi_http_client_spec.rb
@@ -43,6 +43,24 @@ module VSphereCloud
         response = http_client.get("https://localhost:#{@server.port}")
         expect(response.body).to eq('success')
       end
+
+      context 'when ca_cert_file is an empty or blank string' do
+        let(:ca_cert_file) { '' }
+
+        it 'treats it like no bundle and skips TLS verification' do
+          expect(backing_client.ssl_config.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+          response = http_client.get("https://localhost:#{@server.port}")
+          expect(response.body).to eq('success')
+        end
+      end
+
+      context 'when ca_cert_file is only whitespace' do
+        let(:ca_cert_file) { "  \t  " }
+
+        it 'treats it like no bundle' do
+          expect(backing_client.ssl_config.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+        end
+      end
     end
   end
 end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_http_client_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_http_client_spec.rb
@@ -21,6 +21,14 @@ module VSphereCloud
         end
       end
 
+      context 'when ca_cert_file is an empty string' do
+        let(:ca_cert_file) { '' }
+
+        it 'does not validate the NSX certificate when connecting' do
+          expect(backing_client.ssl_config.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+        end
+      end
+
       context 'when the CA cert file provided signs the NSX cert' do
         let(:ca_cert_file) { certificate(:success).path }
 


### PR DESCRIPTION
Also, defer creation of the VM tagging client until it is actually used instead of making it upfront whether we need it or not.

# Description

This PR introduces two primary improvements to the VM tagging functionality: opt-in TLS verification and lazy initialization of the tagging client.

## What changed?
1. **Opt-in TLS Verification for VM Tagging:** Updated `AttachTagToVm.InitializeConnection` to check for `ca_cert_file` within `vcenter_connection_options`. 
   * If a CA certificate is present, it explicitly sets `verify_ssl = true` and `verify_ssl_host = true`, securely pinning the connection. 
   * If absent, it falls back to the previous behavior (`false`) to ensure backward compatibility for existing deployments using self-signed certs without an explicit CA configured.
   
2. **Lazy Initialization of Tagging Client:** Refactored `cloud.rb` to prevent the eager creation of the `tagging_tagger` object during `Cloud#initialize`. It now uses memoization (`||=`) inside a `tagging_tagger` method. This prevents the CPI from establishing an unnecessary CIS tagging REST session until the tagging functionality is actually invoked.
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Impacted Areas in Application
List general components of the application that this PR will affect:
VM Tagging

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

   * Added unit tests in `attach_tag_to_vm_spec.rb` to verify connection options handle CA presence/absence correctly.
   * Added unit tests in `cloud_spec.rb` to ensure the tagging REST session is not created upon initialization (0 calls) until first use (1 call).
   * Updated integration tests to accommodate the connection options payload.

# Checklist:

- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
