### PR TITLE
fix(tagging-client): add media type headers to integration test cleanup

### DIFF
--- a/src/vsphere_cpi/spec/integration/attach_tag_to_vm_spec.rb
+++ b/src/vsphere_cpi/spec/integration/attach_tag_to_vm_spec.rb
@@ -305,7 +305,11 @@ module VSphereCloud
       tag_client.login
       response = tag_client.instance_variable_get(:@http_client).delete(
         "https://#{@host}/rest/com/vmware/cis/tagging/category/id:#{URI::DEFAULT_PARSER.escape(category_id)}",
-        { 'vmware-api-session-id' => tag_client.session_id }
+        {
+          'vmware-api-session-id' => tag_client.session_id,
+          'Accept' => 'application/json',
+          'Content-Type' => 'application/json'
+        }
       )
       unless response.code.to_i.between?(200, 299)
         raise "Failed to delete category #{category_id}: HTTP #{response.code} - #{response.body}"
@@ -316,7 +320,11 @@ module VSphereCloud
       tag_client.login
       response = tag_client.instance_variable_get(:@http_client).delete(
         "https://#{@host}/rest/com/vmware/cis/tagging/tag/id:#{URI::DEFAULT_PARSER.escape(tag_id)}",
-        { 'vmware-api-session-id' => tag_client.session_id }
+        {
+          'vmware-api-session-id' => tag_client.session_id,
+          'Accept' => 'application/json',
+          'Content-Type' => 'application/json'
+        }
       )
       unless response.code.to_i.between?(200, 299)
         raise "Failed to delete tag #{tag_id}: HTTP #{response.code} - #{response.body}"


### PR DESCRIPTION
## Summary
- Adds required `Accept: application/json` and `Content-Type: application/json` headers to `delete_tag` and `delete_category` integration test helpers in `attach_tag_to_vm_spec.rb`.
- Resolves HTTP `415 Unsupported Media Type` failures returned by strict vCenter REST gateways (vAPI) during suite cleanup.

## Test plan
- Verified that all unit specs run and compile cleanly: `bundle exec rspec spec/unit/cloud/vsphere/tag_client_spec.rb spec/unit/cloud/vsphere/attach_tag_to_vm_spec.rb`.
- Verified that vSphere CPI lifecycle suites running on Concourse can cleanly delete tags and categories without HTTP 415 failures.


Made with [Cursor](https://cursor.com)