### PR TITLE
fix(http-client): pass additional_headers correctly in DELETE requests

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/base_http_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/base_http_client.rb
@@ -83,7 +83,7 @@ module VSphereCloud
           when 'POST'
             resp = @backing_client.post(url, content, additional_headers)
           when 'DELETE'
-            resp = @backing_client.delete(url, additional_headers)
+            resp = @backing_client.delete(url, nil, additional_headers)
           else
             raise "Invalid HTTP method '#{method}'"
         end

--- a/src/vsphere_cpi/spec/support/https_helpers.rb
+++ b/src/vsphere_cpi/spec/support/https_helpers.rb
@@ -120,6 +120,26 @@ module Support
               }
             end
 
+            map '/delete-test' do
+              run lambda { |env|
+                req = Rack::Request.new(env)
+                headers = {}
+                env.each do |key, value|
+                  if key.start_with?('HTTP_')
+                    headers[key.sub(/^HTTP_/, '').downcase.gsub('_', '-')] = value
+                  end
+                end
+                response = Rack::Response.new
+                response.headers['Content-Type'] = 'application/json'
+                response.write(JSON.generate({
+                  'method' => req.request_method,
+                  'headers' => headers,
+                  'body' => req.body.read
+                }))
+                response.finish
+              }
+            end
+
             run lambda { |env| [200, { 'Content-Type' => 'text/plain'}, ['success']] }
           }, **server_config)
         end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/base_http_client_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/base_http_client_spec.rb
@@ -220,6 +220,17 @@ module VSphereCloud
         response = http_client.delete(url)
         expect(response.status).to eq(200)
       end
+
+      it 'passes headers correctly and sends nil body (live HTTP socket round-trip test)' do
+        url = "https://localhost:#{@server.port}/delete-test"
+        response = http_client.delete(url, { "x-custom-test-header" => "custom-value" })
+        expect(response.status).to eq(200)
+
+        payload = JSON.parse(response.body)
+        expect(payload['method']).to eq('DELETE')
+        expect(payload['headers']['x-custom-test-header']).to eq('custom-value')
+        expect(payload['body']).to eq('')
+      end
     end
 
 


### PR DESCRIPTION
## Summary
- Corrects `BaseHttpClient#delete` parameter mapping to pass `nil` as the request body argument, which correctly maps the `additional_headers` parameter to the third position (`:header` block) of the backing `HTTPClient#delete` method.
- Previously, headers were passed as the second argument, which mapped to the request body, causing headers to be serialized into the body and omitted from the actual HTTP headers, triggering HTTP `415 Unsupported Media Type` failures on strict gateways.
- Adds a live secure SSL socket round-trip test mapping the request on a mock server route, validating that custom headers are sent correctly and the body remains empty.

## Test plan
- All unit tests run and pass cleanly locally: `bundle exec rspec spec/unit/cloud/vsphere/base_http_client_spec.rb`.
- Verification via a live SSL socket round-trip test against a mock WEBrick server confirming proper parameter position mapping on the wire.


Made with [Cursor](https://cursor.com)