### PR TITLE
fix: add missing require 'cgi' to file_provider.rb

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/file_provider.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/file_provider.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 require 'cloud/vsphere/logger'
 
 module VSphereCloud


### PR DESCRIPTION
## Summary

- The `vsphere-automation-sdk` gems removed in #464 were transitively `require`-ing the stdlib `cgi` gem, which made `CGI.escape` available in `file_provider.rb` without an explicit require.
- With those gems gone, `CGI` is no longer auto-loaded, causing every `create_vm` call to fail with `uninitialized constant VSphereCloud::FileProvider::CGI`.
- Fix: add `require 'cgi'` explicitly at the top of `file_provider.rb`.

## Test plan

- [ ] Trigger `vsphere-cpi-oss/bats` in CI and confirm it passes `create_vm` without the `CGI` constant error.

Made with [Cursor](https://cursor.com)