### PR TITLE
Stop stripping out the mbus boostrap cert

### DIFF
--- a/ci/pipeline/main.yml.erb
+++ b/ci/pipeline/main.yml.erb
@@ -205,7 +205,6 @@ jobs:
           OPTIONAL_OPS_FILE:  |
             -o certification/shared/assets/ops/remove-hm.yml
             -o bosh-deployment/vsphere/resource-pool.yml
-            -o certification/shared/assets/ops/remove-provider-cert.yml
       - do:
           - task: deploy-director
             tags: [nimbus]
@@ -282,7 +281,6 @@ jobs:
           OPTIONAL_OPS_FILE:  |
             -o certification/shared/assets/ops/remove-hm.yml
             -o bosh-deployment/vsphere/resource-pool.yml
-            -o certification/shared/assets/ops/remove-provider-cert.yml
       - do:
         - task: deploy-director
           tags: [nimbus]
@@ -357,7 +355,6 @@ jobs:
           OPTIONAL_OPS_FILE:  |
             -o certification/shared/assets/ops/remove-hm.yml
             -o bosh-deployment/vsphere/resource-pool.yml
-            -o certification/shared/assets/ops/remove-provider-cert.yml
       - do:
           - task: deploy-director
             tags: [nimbus]
@@ -432,7 +429,6 @@ jobs:
           OPTIONAL_OPS_FILE:  |
             -o certification/shared/assets/ops/remove-hm.yml
             -o bosh-deployment/vsphere/resource-pool.yml
-            -o certification/shared/assets/ops/remove-provider-cert.yml
       - do:
           - task: deploy-director
             tags: [nimbus]
@@ -506,7 +502,6 @@ jobs:
           OPTIONAL_OPS_FILE:  |
             -o certification/shared/assets/ops/remove-hm.yml
             -o bosh-deployment/vsphere/resource-pool.yml
-            -o certification/shared/assets/ops/remove-provider-cert.yml
       - do:
           - task: deploy-director
             tags: [nimbus]


### PR DESCRIPTION
...during create-env operations. We used to tolerate not having a CA for the mbus bootstrap endpoint, but now this causes failures. Also it is unnecessary.
