### PR TITLE
Exclude localhost/director from proxying

### DIFF
--- a/ci/shared/tasks/setup-env-proxy.sh
+++ b/ci/shared/tasks/setup-env-proxy.sh
@@ -3,7 +3,8 @@
 source environment/metadata
 export HTTP_PROXY="http://$BOSH_VSPHERE_JUMPER_HOST:80"
 export HTTPS_PROXY="http://$BOSH_VSPHERE_JUMPER_HOST:80"
-export NO_PROXY=.amazonaws.com,rubygems.org,gcr.io
+export NO_PROXY=localhost,127.0.0.1,30.0.1.1,.amazonaws.com,rubygems.org,gcr.io
+export no_proxy="$NO_PROXY"
 
 private_key_path=$(mktemp)
 echo -e "${JUMPBOX_PRIVATE_KEY}" > ${private_key_path}


### PR DESCRIPTION
Since e932c2a9, we are now validating TLS between the cli and director. However, without an appropriate NO_PROXY for the director, we get the proxy's TLS cert and not the director's.