### PR TITLE
Revert "Exclude localhost/director from proxying"

### DIFF
--- a/ci/shared/tasks/setup-env-proxy.sh
+++ b/ci/shared/tasks/setup-env-proxy.sh
@@ -3,8 +3,7 @@
 source environment/metadata
 export HTTP_PROXY="http://$BOSH_VSPHERE_JUMPER_HOST:80"
 export HTTPS_PROXY="http://$BOSH_VSPHERE_JUMPER_HOST:80"
-export NO_PROXY=localhost,127.0.0.1,30.0.1.1,.amazonaws.com,rubygems.org,gcr.io
-export no_proxy="$NO_PROXY"
+export NO_PROXY=.amazonaws.com,rubygems.org,gcr.io
 
 private_key_path=$(mktemp)
 echo -e "${JUMPBOX_PRIVATE_KEY}" > ${private_key_path}


### PR DESCRIPTION
Reverts cloudfoundry/bosh-vsphere-cpi-release#471

Barking up the wrong tree - turns out the pipeline wasn't flown after some changes were made, leading to BATs failing 100% of the time 🤦 